### PR TITLE
Benchmark with BenchmarkDotNet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# BenchmarkDotNet results
+BenchmarkDotNet.Artifacts

--- a/BenchmarkApp/BenchmarkApp.csproj
+++ b/BenchmarkApp/BenchmarkApp.csproj
@@ -2,10 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
   </ItemGroup>
 
@@ -13,12 +15,13 @@
     <ProjectReference Include="..\NodeServicesBenchmark\NodeServicesBenchmark.csproj" />
   </ItemGroup>
 
-  <!-- https://github.com/aspnet/Hosting/issues/954#issuecomment-287903687 -->
+  <!--
+    https://github.com/aspnet/Mvc/blob/66deaf0b3fb935027730cf470cf6a331e69f2cee/test/Microsoft.AspNetCore.Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj#L79-L85
+  -->
   <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
     <ItemGroup>
       <DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
     </ItemGroup>
-
     <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
   </Target>
 </Project>

--- a/BenchmarkApp/Program.cs
+++ b/BenchmarkApp/Program.cs
@@ -1,37 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
+using BenchmarkDotNet.Running;
 
 namespace BenchmarkApp
 {
-    internal class Program
+    internal static class Program
     {
-        private static readonly IDictionary<string, double> Results = new Dictionary<string, double>();
-        private const int TestRunCount = 1000;
-
-        private static void Main()
+        public static void Main(string[] args)
         {
-            RunTest(title: "No Template Service", url: "/no-template", testRuns: TestRunCount);
-            RunTest(title: "With Template Service", url: "/with-template", testRuns: TestRunCount);
-            RunTest(title: "With Cached Template Service", url: "/with-cached-template", testRuns: TestRunCount);
+            BenchmarkRunner.Run<ViewComponentBenchmarks>();
 
-            DisplayResults();
-        }
-
-        private static void RunTest(string title, string url, int testRuns)
-        {
-            using (var test = new ViewComponentBenchmarks(url, testRuns))
-            {
-                var time = test.RunTests().Result;
-                Results.Add(title, time);
-            }
-        }
-
-        private static void DisplayResults()
-        {
-            foreach (var result in Results)
-            {
-                Console.WriteLine($"{result.Key} ran {TestRunCount} times with an average time of {result.Value:N2} milliseconds.");
-            }
+            Console.Write("Press enter to exit...");
+            Console.ReadLine();
         }
     }
 }

--- a/BenchmarkApp/ViewComponentBenchmarks.cs
+++ b/BenchmarkApp/ViewComponentBenchmarks.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.PlatformAbstractions;
 using NodeServicesBenchmark;
 
@@ -14,69 +18,108 @@ namespace BenchmarkApp
 {
     public class ViewComponentBenchmarks : IDisposable
     {
+        // Code to get stuff working borrowed from https://github.com/aspnet/Mvc/blob/e1c1682065724bbf8e245d40cb32b300c07505bb/src/Microsoft.AspNetCore.Mvc.Testing/MvcWebApplicationBuilder.cs
 
         private readonly HttpClient _client;
         private readonly TestServer _server;
-        private readonly IList<long> _results;
-        private readonly string _testUrl;
-        private readonly int _testRuns;
 
-        private static string ContentPath
+        public List<Assembly> ApplicationAssemblies { get; set; } = new List<Assembly>();
+
+        public ViewComponentBenchmarks()
         {
-            get
+            var depsFileName = $"{typeof(Startup).GetTypeInfo().Assembly.GetName().Name}.deps.json";
+            var depsFile = new FileInfo(Path.Combine(AppContext.BaseDirectory, depsFileName));
+
+            var requiredPath = depsFile.FullName;
+
+            // HACK Ensure that the BenchmarkDotNet generated folder contains the .deps.json files
+            while (!depsFile.Exists)
             {
-                var path = PlatformServices.Default.Application.ApplicationBasePath;
-                var contentPath = Path.GetFullPath(Path.Combine(path, $@"..\..\..\..\{nameof(NodeServicesBenchmark)}"));
-                return contentPath;
+                depsFile = new FileInfo(Path.Combine(depsFile.DirectoryName, "..", depsFileName));
             }
-        }
 
-        public ViewComponentBenchmarks(string testUrl, int testRuns)
-        {
-            _testUrl = testUrl;
-            _testRuns = testRuns;
+            if (depsFile.FullName != requiredPath)
+            {
+                File.Copy(depsFile.FullName, requiredPath);
+            }
+            // ENDHACK
+
+            ApplicationAssemblies.AddRange(DefaultAssemblyPartDiscoveryProvider
+                .DiscoverAssemblyParts(typeof(Startup).GetTypeInfo().Assembly.GetName().Name)
+                .Select(s => ((AssemblyPart)s).Assembly)
+                .ToList());
 
             var builder = new WebHostBuilder()
-                .UseContentRoot(ContentPath)
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .UseSetting(WebHostDefaults.ApplicationKey, typeof(Startup).GetTypeInfo().Assembly.GetName().Name)
+                .UseContentRoot(GetProjectPath<Startup>())
+                .ConfigureServices(InitializeServices);
 
             _server = new TestServer(builder);
-
             _client = _server.CreateClient();
-            _client.BaseAddress = new UriBuilder { Port = 5001 }.Uri;
-
-            _results = new List<long>();
         }
 
-        public async Task<double> RunTests()
-        {
-            for (var i = 0; i < _testRuns; i++)
-            {
-                await RunTest();
-            }
+        [Benchmark(Baseline = true)]
+        public async Task No_Template() => await HttpGet("no-template");
 
-            // Remove the first result from the list as this include the time taken to spin up the test server
-            var averageTime = _results.Skip(1).Average();
-            return averageTime;
-        }
-
+        [Benchmark]
+        public async Task With_Template() => await HttpGet("with-template");
         
-        public async Task RunTest()
-        {
-            var watch = Stopwatch.StartNew();
+        [Benchmark]
+        public async Task With_Cached_Template() => await HttpGet("with-cached-template");
 
-            var response = await _client.GetAsync(_testUrl);
-            await response.Content.ReadAsStringAsync();
-
-            watch.Stop();
-            var elapsedTime = watch.ElapsedMilliseconds;
-            _results.Add(elapsedTime);
-        }
+        private async Task HttpGet(string uri) => await _client.GetStringAsync(uri);
 
         public void Dispose()
         {
             _client?.Dispose();
             _server?.Dispose();
+        }
+
+        protected virtual void InitializeServices(IServiceCollection services)
+        {
+            var manager = new ApplicationPartManager();
+
+            foreach (var assembly in ApplicationAssemblies)
+            {
+                manager.ApplicationParts.Add(new AssemblyPart(assembly));
+            }
+
+            services.AddSingleton(manager);
+        }
+
+        private static string GetProjectPath<TStartup>()
+        {
+            var startupAssembly = typeof(TStartup).GetTypeInfo().Assembly;
+            return GetProjectPath(".", startupAssembly);
+        }
+
+        private static string GetProjectPath(string solutionRelativePath, Assembly startupAssembly)
+        {
+            string projectName = startupAssembly.GetName().Name;
+            string solutionName = "NodeServicesBenchmark.sln";
+            string applicationBasePath = PlatformServices.Default.Application.ApplicationBasePath;
+
+            // Find the directory containing the solution file
+            DirectoryInfo directoryInfo = new DirectoryInfo(applicationBasePath);
+
+            do
+            {
+                string fileName = Path.Combine(directoryInfo.FullName, solutionName);
+
+                FileInfo solutionFileInfo = new FileInfo(fileName);
+
+                if (solutionFileInfo.Exists)
+                {
+                    string contentRoot = Path.Combine(directoryInfo.FullName, solutionRelativePath, projectName);
+                    return Path.GetFullPath(contentRoot);
+                }
+
+                directoryInfo = directoryInfo.Parent;
+            }
+            while (directoryInfo.Parent != null);
+
+            throw new FileNotFoundException($"Solution file could not be located using application root '{applicationBasePath}'.", solutionName);
         }
     }
 }

--- a/NodeServicesBenchmark/package-lock.json
+++ b/NodeServicesBenchmark/package-lock.json
@@ -1,0 +1,17613 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@gulp-sourcemaps/identity-map": {
+      "version": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
+      "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+        "css": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "integrity": "sha1-U/4WERH5EquZnuiHqQoLxSgi/XU="
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "@gulp-sourcemaps/map-sources": {
+      "version": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+      "requires": {
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "@justeat/eslint-config-fozzie": {
+      "version": "http://packages.je-labs.com/npm/private-npm/@justeat/eslint-config-fozzie/-/eslint-config-fozzie-1.2.0.tgz",
+      "integrity": "sha1-u/1F34rdXIhzGHODO1H/EHwDa64=",
+      "requires": {
+        "eslint-config-airbnb-base": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz"
+      }
+    },
+    "@justeat/f-header": {
+      "version": "file:justeat-f-header-v0.5.0.tgz",
+      "integrity": "sha1-37PDZHuXnZN5hZjJsy2FdVtHlYU=",
+      "requires": {
+        "@justeat/fozzie-colour-palette": "http://packages.je-labs.com/npm/private-npm/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.1.1.tgz",
+        "@justeat/gulp-build-fozzie": "http://packages.je-labs.com/npm/private-npm/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-3.1.0.tgz",
+        "@kickoff/utils.scss": "https://registry.npmjs.org/@kickoff/utils.scss/-/utils.scss-2.1.1.tgz",
+        "babel-preset-es2015": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+        "include-media": "https://registry.npmjs.org/include-media/-/include-media-1.4.9.tgz"
+      }
+    },
+    "@justeat/fozzie-colour-palette": {
+      "version": "http://packages.je-labs.com/npm/private-npm/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.1.1.tgz",
+      "integrity": "sha1-O/+j8ehvq6abkhwQ0A0ul7v4zzc=",
+      "requires": {
+        "@justeat/gulp-build-fozzie": "http://packages.je-labs.com/npm/private-npm/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-1.17.0.tgz"
+      },
+      "dependencies": {
+        "@justeat/gulp-build-fozzie": {
+          "version": "http://packages.je-labs.com/npm/private-npm/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-1.17.0.tgz",
+          "integrity": "sha1-Ksbtr/qQoe/3JLDqblYz67icsrM=",
+          "requires": {
+            "@justeat/eslint-config-fozzie": "http://packages.je-labs.com/npm/private-npm/@justeat/eslint-config-fozzie/-/eslint-config-fozzie-1.2.0.tgz",
+            "@justeat/stylelint-config-fozzie": "https://registry.npmjs.org/@justeat/stylelint-config-fozzie/-/stylelint-config-fozzie-0.1.4.tgz",
+            "assemble": "https://registry.npmjs.org/assemble/-/assemble-0.24.3.tgz",
+            "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.2.tgz",
+            "babelify": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+            "browser-sync": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
+            "browserify": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
+            "cssnano": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+            "eslint": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+            "eslint-plugin-import": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+            "eslint-plugin-jest": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz",
+            "exorcist": "https://registry.npmjs.org/exorcist/-/exorcist-0.4.0.tgz",
+            "expand": "https://registry.npmjs.org/expand/-/expand-0.5.0.tgz",
+            "eyeglass": "https://registry.npmjs.org/eyeglass/-/eyeglass-1.2.1.tgz",
+            "filesizegzip": "https://registry.npmjs.org/filesizegzip/-/filesizegzip-2.0.0.tgz",
+            "gulp": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+            "gulp-cached": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
+            "gulp-changed": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-3.1.0.tgz",
+            "gulp-debug": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-3.1.0.tgz",
+            "gulp-eslint": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-4.0.0.tgz",
+            "gulp-extname": "https://registry.npmjs.org/gulp-extname/-/gulp-extname-0.2.2.tgz",
+            "gulp-filenames": "https://registry.npmjs.org/gulp-filenames/-/gulp-filenames-4.0.1.tgz",
+            "gulp-if": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+            "gulp-imagemin": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-3.3.0.tgz",
+            "gulp-newer": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.3.0.tgz",
+            "gulp-plumber": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
+            "gulp-postcss": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.0.tgz",
+            "gulp-rename": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+            "gulp-rev": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-7.1.2.tgz",
+            "gulp-sass": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
+            "gulp-size": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.1.0.tgz",
+            "gulp-sourcemaps": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.0.tgz",
+            "gulp-svgmin": "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-1.2.4.tgz",
+            "gulp-svgstore": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.1.0.tgz",
+            "gulp-tap": "https://registry.npmjs.org/gulp-tap/-/gulp-tap-1.0.1.tgz",
+            "gulp-uglify": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
+            "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+            "handlebars-helpers": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.8.4.tgz",
+            "helper-markdown": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.2.tgz",
+            "helper-md": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz",
+            "jest-cli": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+            "postcss-assets": "https://registry.npmjs.org/postcss-assets/-/postcss-assets-4.2.0.tgz",
+            "postcss-reporter": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-4.0.0.tgz",
+            "postcss-scss": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.2.tgz",
+            "require-dir": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
+            "run-sequence": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+            "stylelint": "https://registry.npmjs.org/stylelint/-/stylelint-7.13.0.tgz",
+            "sw-precache": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.0.tgz",
+            "vinyl-buffer": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
+            "vinyl-source-stream": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz"
+          }
+        }
+      }
+    },
+    "@justeat/gulp-build-fozzie": {
+      "version": "http://packages.je-labs.com/npm/private-npm/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-3.1.0.tgz",
+      "integrity": "sha1-ezfy8u4TtCcLk5wkKz9/rPGGhZk=",
+      "requires": {
+        "@justeat/eslint-config-fozzie": "http://packages.je-labs.com/npm/private-npm/@justeat/eslint-config-fozzie/-/eslint-config-fozzie-1.2.0.tgz",
+        "@justeat/stylelint-config-fozzie": "http://packages.je-labs.com/npm/private-npm/@justeat/stylelint-config-fozzie/-/stylelint-config-fozzie-1.1.0.tgz",
+        "assemble": "https://registry.npmjs.org/assemble/-/assemble-0.24.3.tgz",
+        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.2.tgz",
+        "babelify": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+        "browser-sync": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
+        "browserify": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
+        "cssnano": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+        "eslint": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+        "eslint-plugin-import": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+        "eslint-plugin-jest": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz",
+        "exorcist": "https://registry.npmjs.org/exorcist/-/exorcist-0.4.0.tgz",
+        "expand": "https://registry.npmjs.org/expand/-/expand-0.5.0.tgz",
+        "eyeglass": "https://registry.npmjs.org/eyeglass/-/eyeglass-1.2.1.tgz",
+        "filesizegzip": "https://registry.npmjs.org/filesizegzip/-/filesizegzip-2.0.0.tgz",
+        "gulp": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+        "gulp-cached": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
+        "gulp-changed": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-3.1.0.tgz",
+        "gulp-debug": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-3.1.0.tgz",
+        "gulp-eslint": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-4.0.0.tgz",
+        "gulp-extname": "https://registry.npmjs.org/gulp-extname/-/gulp-extname-0.2.2.tgz",
+        "gulp-filenames": "https://registry.npmjs.org/gulp-filenames/-/gulp-filenames-4.0.1.tgz",
+        "gulp-if": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+        "gulp-imagemin": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-3.3.0.tgz",
+        "gulp-newer": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.3.0.tgz",
+        "gulp-plumber": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
+        "gulp-postcss": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.0.tgz",
+        "gulp-rename": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+        "gulp-rev": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-7.1.2.tgz",
+        "gulp-sass": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
+        "gulp-size": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.1.0.tgz",
+        "gulp-sourcemaps": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.0.tgz",
+        "gulp-strip-debug": "https://registry.npmjs.org/gulp-strip-debug/-/gulp-strip-debug-1.1.0.tgz",
+        "gulp-svgmin": "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-1.2.4.tgz",
+        "gulp-svgstore": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.1.0.tgz",
+        "gulp-tap": "https://registry.npmjs.org/gulp-tap/-/gulp-tap-1.0.1.tgz",
+        "gulp-uglify": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "handlebars-helpers": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.9.6.tgz",
+        "helper-markdown": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-1.0.0.tgz",
+        "helper-md": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz",
+        "jest-cli": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+        "postcss-assets": "https://registry.npmjs.org/postcss-assets/-/postcss-assets-4.2.0.tgz",
+        "postcss-reporter": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-4.0.0.tgz",
+        "postcss-scss": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.2.tgz",
+        "require-dir": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
+        "run-sequence": "https://registry.npmjs.org/run-sequence/-/run-sequence-2.1.0.tgz",
+        "stylelint": "https://registry.npmjs.org/stylelint/-/stylelint-8.0.0.tgz",
+        "sw-precache": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.0.tgz",
+        "vinyl-buffer": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
+        "vinyl-source-stream": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz"
+      },
+      "dependencies": {
+        "@justeat/stylelint-config-fozzie": {
+          "version": "http://packages.je-labs.com/npm/private-npm/@justeat/stylelint-config-fozzie/-/stylelint-config-fozzie-1.1.0.tgz",
+          "integrity": "sha1-vl8XojNvDUL/X0XeC/a/iMLUuCU="
+        },
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "requires": {
+            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+          }
+        },
+        "arr-diff": {
+          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "array-unique": {
+          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "braces": {
+          "version": "https://registry.npmjs.org/braces/-/braces-2.2.2.tgz",
+          "integrity": "sha1-JB+GjCsmkNn+vu5afIP7vyXQCxs=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "snapdragon": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+            "snapdragon-node": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "split-string": "https://registry.npmjs.org/split-string/-/split-string-2.1.1.tgz",
+            "to-regex": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz"
+          }
+        },
+        "define-property": {
+          "version": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz"
+          }
+        },
+        "expand-brackets": {
+          "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "define-property": "0.2.5",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "posix-character-classes": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "regex-not": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+            "snapdragon": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+            "to-regex": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "https://registry.npmjs.org/extglob/-/extglob-1.1.0.tgz",
+          "integrity": "sha1-Bni04s5FwOTlD15er7Gw2rW05CQ=",
+          "requires": {
+            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "define-property": "0.2.5",
+            "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "fragment-cache": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "regex-not": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+            "snapdragon": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+            "to-regex": "https://registry.npmjs.org/to-regex/-/to-regex-2.1.0.tgz"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz"
+              }
+            },
+            "to-regex": {
+              "version": "https://registry.npmjs.org/to-regex/-/to-regex-2.1.0.tgz",
+              "integrity": "sha1-4606QM/hGVWaBa6kPkyu+sxekB0=",
+              "requires": {
+                "define-property": "0.2.5",
+                "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                "regex-not": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.2.tgz"
+              },
+              "dependencies": {
+                "regex-not": {
+                  "version": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.2.tgz",
+                  "integrity": "sha1-vH8cSUSxGINT0H3uuRK5TgreJds="
+                }
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "to-regex-range": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz"
+          }
+        },
+        "for-own": {
+          "version": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "requires": {
+            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "globby": {
+          "version": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "pify": "2.3.0",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            }
+          }
+        },
+        "handlebars-helpers": {
+          "version": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.9.6.tgz",
+          "integrity": "sha1-t/5cBRmD1VtpiY42IQ702Meb0Bs=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "array-sort": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.3.tgz",
+            "create-frame": "https://registry.npmjs.org/create-frame/-/create-frame-1.0.0.tgz",
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+            "falsey": "https://registry.npmjs.org/falsey/-/falsey-0.3.0.tgz",
+            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "for-own": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+            "get-object": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+            "handlebars-helper-create-frame": "https://registry.npmjs.org/handlebars-helper-create-frame/-/handlebars-helper-create-frame-0.1.0.tgz",
+            "handlebars-utils": "https://registry.npmjs.org/handlebars-utils/-/handlebars-utils-1.0.2.tgz",
+            "has-value": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "helper-date": "https://registry.npmjs.org/helper-date/-/helper-date-1.0.0.tgz",
+            "helper-markdown": "0.2.2",
+            "helper-md": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz",
+            "html-tag": "https://registry.npmjs.org/html-tag/-/html-tag-1.0.0.tgz",
+            "is-even": "https://registry.npmjs.org/is-even/-/is-even-1.0.0.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "logging-helpers": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-1.0.0.tgz",
+            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-3.0.4.tgz",
+            "relative": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+            "striptags": "https://registry.npmjs.org/striptags/-/striptags-3.0.1.tgz",
+            "to-gfm-code-block": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
+            "year": "https://registry.npmjs.org/year/-/year-0.2.1.tgz"
+          },
+          "dependencies": {
+            "helper-markdown": {
+              "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.2.tgz",
+              "integrity": "sha1-ONt/dxhJ4wrpXJL8AhuutT8uMEA=",
+              "requires": {
+                "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+                "remarkable": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz"
+              }
+            },
+            "isobject": {
+              "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              }
+            }
+          }
+        },
+        "has-value": {
+          "version": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "requires": {
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "has-values": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          }
+        },
+        "has-values": {
+          "version": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "helper-date": {
+          "version": "https://registry.npmjs.org/helper-date/-/helper-date-1.0.0.tgz",
+          "integrity": "sha1-4RGDkemvS4HuBLM7wqdqaLbNX20=",
+          "requires": {
+            "date.js": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
+            "handlebars-utils": "https://registry.npmjs.org/handlebars-utils/-/handlebars-utils-1.0.2.tgz",
+            "moment": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
+          }
+        },
+        "helper-markdown": {
+          "version": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-1.0.0.tgz",
+          "integrity": "sha1-7n6fxVRnUAfTfrkPeFOxPOdPPhA=",
+          "requires": {
+            "handlebars-utils": "https://registry.npmjs.org/handlebars-utils/-/handlebars-utils-1.0.2.tgz",
+            "highlight.js": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+            "remarkable": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz"
+          }
+        },
+        "is-descriptor": {
+          "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+          "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
+          "requires": {
+            "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz"
+          }
+        },
+        "is-even": {
+          "version": "https://registry.npmjs.org/is-even/-/is-even-1.0.0.tgz",
+          "integrity": "sha1-drUFX7rY0pSoa2qUkBXhyXtxfAY=",
+          "requires": {
+            "is-odd": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz"
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "logging-helpers": {
+          "version": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-1.0.0.tgz",
+          "integrity": "sha1-taN7Mq1T6wE3xYx4mKR7F13bfDY=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz"
+          }
+        },
+        "micromatch": {
+          "version": "https://registry.npmjs.org/micromatch/-/micromatch-3.0.4.tgz",
+          "integrity": "sha1-FUPx0EgTRHrIUgAcX1qTNAF4bR0=",
+          "requires": {
+            "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "braces": "https://registry.npmjs.org/braces/-/braces-2.2.2.tgz",
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "extglob": "https://registry.npmjs.org/extglob/-/extglob-1.1.0.tgz",
+            "fragment-cache": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+            "nanomatch": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.0.tgz",
+            "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+            "regex-not": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+            "snapdragon": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+            "to-regex": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "pify": {
+          "version": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "postcss-less": {
+          "version": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.0.tgz",
+          "integrity": "sha1-vcx2vmTEMk2HP7xc2foueZ5DBfo=",
+          "requires": {
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+            },
+            "postcss": {
+              "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+              "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+              "requires": {
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+              }
+            },
+            "supports-color": {
+              "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "requires": {
+                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              }
+            }
+          }
+        },
+        "resolve-from": {
+          "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        },
+        "run-sequence": {
+          "version": "https://registry.npmjs.org/run-sequence/-/run-sequence-2.1.0.tgz",
+          "integrity": "sha1-FJ2gElFvIdz3nbbcmaKpVgNjGyE=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "split-string": {
+          "version": "https://registry.npmjs.org/split-string/-/split-string-2.1.1.tgz",
+          "integrity": "sha1-r0sG2CFWBCZEbDzZMc2mGJQNN9A=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+          }
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          }
+        },
+        "strip-ansi": {
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+          }
+        },
+        "striptags": {
+          "version": "https://registry.npmjs.org/striptags/-/striptags-3.0.1.tgz",
+          "integrity": "sha1-SPDWkyVJxHuzWCkgyHUnz0mhYME="
+        },
+        "stylelint": {
+          "version": "https://registry.npmjs.org/stylelint/-/stylelint-8.0.0.tgz",
+          "integrity": "sha1-h2ESEXdssxXJP89sWLwmHTySYS4=",
+          "requires": {
+            "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.2.tgz",
+            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+            "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "execall": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+            "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+            "globby": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+            "globjoin": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+            "html-tags": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+            "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "known-css-properties": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+            "mathml-tag-names": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "micromatch": "2.3.11",
+            "normalize-selector": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+            "postcss-less": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.0.tgz",
+            "postcss-media-query-parser": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+            "postcss-reporter": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-4.0.0.tgz",
+            "postcss-resolve-nested-selector": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+            "postcss-scss": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.2.tgz",
+            "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+            "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+            "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            "specificity": "https://registry.npmjs.org/specificity/-/specificity-0.3.1.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "style-search": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+            "sugarss": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.0.tgz",
+            "svg-tags": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+            "table": "https://registry.npmjs.org/table/-/table-4.0.1.tgz"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+              "requires": {
+                "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+            },
+            "braces": {
+              "version": "1.8.5",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+              "requires": {
+                "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+              }
+            },
+            "chalk": {
+              "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+              "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+              "requires": {
+                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+              "requires": {
+                "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+              "requires": {
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+              }
+            },
+            "is-glob": {
+              "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "requires": {
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+              }
+            },
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+              }
+            }
+          }
+        },
+        "sugarss": {
+          "version": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.0.tgz",
+          "integrity": "sha1-ZeUbOVhDL7cNVFGmi7M+MtDPHvc=",
+          "requires": {
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz"
+          }
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+          }
+        }
+      }
+    },
+    "@justeat/stylelint-config-fozzie": {
+      "version": "https://registry.npmjs.org/@justeat/stylelint-config-fozzie/-/stylelint-config-fozzie-0.1.4.tgz",
+      "integrity": "sha1-Tw/e9ziQvvZ/7L6yIWFOoyc0Ao8="
+    },
+    "@kickoff/utils.scss": {
+      "version": "https://registry.npmjs.org/@kickoff/utils.scss/-/utils.scss-2.1.1.tgz",
+      "integrity": "sha1-yJ+utM2aRL5119B+X5+jVnM93S0=",
+      "requires": {
+        "release-it": "https://registry.npmjs.org/release-it/-/release-it-2.8.5.tgz"
+      }
+    },
+    "abab": {
+      "version": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
+    },
+    "abbrev": {
+      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+    },
+    "accepts": {
+      "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "requires": {
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+      }
+    },
+    "acorn": {
+      "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+    },
+    "acorn-globals": {
+      "version": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+      }
+    },
+    "acorn-jsx": {
+      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+        }
+      }
+    },
+    "after": {
+      "version": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+      "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
+    },
+    "agent-base": {
+      "version": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "optional": true,
+      "requires": {
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "optional": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+      }
+    },
+    "ajv-keywords": {
+      "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+    },
+    "align-text": {
+      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "alphanum-sort": {
+      "version": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+    },
+    "amdefine": {
+      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-align": {
+      "version": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+      }
+    },
+    "ansi-bgblack": {
+      "version": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
+      "integrity": "sha1-poulAHiHcBtqr74/oNrf36juPKI=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bgblue": {
+      "version": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
+      "integrity": "sha1-Z73ATtybm1J4lp2hlt6j11yMNhM=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bgcyan": {
+      "version": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
+      "integrity": "sha1-WEiUJWAL3p9VBwaN2Wnr/bUP52g=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bggreen": {
+      "version": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
+      "integrity": "sha1-TjGRJIUplD9DIelr8THRwTgWr0k=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bgmagenta": {
+      "version": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
+      "integrity": "sha1-myhDLAduqpmUGGcqPvvhk5HCx6E=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bgred": {
+      "version": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
+      "integrity": "sha1-p2+Sg4OCukMpCmwXeEJPmE1vEEE=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bgwhite": {
+      "version": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
+      "integrity": "sha1-ZQRlE3elim7OzQMxmU5IAljhG6g=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bgyellow": {
+      "version": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
+      "integrity": "sha1-w/4usIzUdmSAKeaHTRWgs49h1E8=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-black": {
+      "version": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
+      "integrity": "sha1-9hheiJNgslRaHsUMC/Bj/EMDJFM=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-blue": {
+      "version": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
+      "integrity": "sha1-FbgEmQ6S/JyoxUds6PaZd3wh7b8=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-bold": {
+      "version": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
+      "integrity": "sha1-PmOVCvWswq4uZw5vZ96xFdGl9QU=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-colors": {
+      "version": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
+      "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
+      "requires": {
+        "ansi-bgblack": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
+        "ansi-bgblue": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
+        "ansi-bgcyan": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
+        "ansi-bggreen": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
+        "ansi-bgmagenta": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
+        "ansi-bgred": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
+        "ansi-bgwhite": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
+        "ansi-bgyellow": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
+        "ansi-black": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
+        "ansi-blue": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
+        "ansi-bold": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
+        "ansi-cyan": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+        "ansi-dim": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
+        "ansi-gray": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+        "ansi-green": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+        "ansi-grey": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
+        "ansi-hidden": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
+        "ansi-inverse": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
+        "ansi-italic": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
+        "ansi-magenta": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
+        "ansi-red": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+        "ansi-reset": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
+        "ansi-strikethrough": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
+        "ansi-underline": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
+        "ansi-white": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
+        "ansi-yellow": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+      }
+    },
+    "ansi-cyan": {
+      "version": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-dim": {
+      "version": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
+      "integrity": "sha1-QN5MYDqoCG2Oeoa4/5mNXDbu/Ww=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-escapes": {
+      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+    },
+    "ansi-gray": {
+      "version": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-green": {
+      "version": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+      "integrity": "sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-grey": {
+      "version": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
+      "integrity": "sha1-WdmLasK6GfilF5jphT+6eDOaM8E=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-hidden": {
+      "version": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
+      "integrity": "sha1-7WpMSY0rt8uyidvyqNHcyFZ/rg8=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-inverse": {
+      "version": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
+      "integrity": "sha1-tq9Fgm/oJr+1KKbHmIV5Q1XM0mk=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-italic": {
+      "version": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
+      "integrity": "sha1-EEdDRj9iXBQqA2c5z4XtpoiYbyM=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-magenta": {
+      "version": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
+      "integrity": "sha1-BjtboW+z8j4c/aKwfAqJ3hHkMK4=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-red": {
+      "version": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-regex": {
+      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-reset": {
+      "version": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
+      "integrity": "sha1-5+cSksPH3c1NYu9KbHwFmAkRw7c=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-strikethrough": {
+      "version": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
+      "integrity": "sha1-2Eh3FAss/wfRyT685pkE9oiF5Wg=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-styles": {
+      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-underline": {
+      "version": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
+      "integrity": "sha1-38kg9Ml7WXfqFi34/7mIMIqqcaQ=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-white": {
+      "version": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
+      "integrity": "sha1-nHe3wZPF7pkuYBHTbsTJIbRXiUQ=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "ansi-wrap": {
+      "version": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "ansi-yellow": {
+      "version": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+      "integrity": "sha1-y5NW8vRscy8OMZnmEClVp32oPB0=",
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
+    },
+    "anymatch": {
+      "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "requires": {
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
+      }
+    },
+    "append-transform": {
+      "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+      "requires": {
+        "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
+      }
+    },
+    "aproba": {
+      "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E="
+    },
+    "archive-type": {
+      "version": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
+      "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
+      "requires": {
+        "file-type": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+        }
+      }
+    },
+    "archy": {
+      "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "are-we-there-yet": {
+      "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "argparse": {
+      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      }
+    },
+    "arr-diff": {
+      "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+      }
+    },
+    "arr-filter": {
+      "version": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "requires": {
+        "make-iterator": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz"
+      }
+    },
+    "arr-flatten": {
+      "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+    },
+    "arr-map": {
+      "version": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "requires": {
+        "make-iterator": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz"
+      }
+    },
+    "arr-pluck": {
+      "version": "https://registry.npmjs.org/arr-pluck/-/arr-pluck-0.1.0.tgz",
+      "integrity": "sha1-+K1tcI+HkAiB4jr9gw1SKQp2Z3U=",
+      "requires": {
+        "arr-map": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz"
+      }
+    },
+    "arr-union": {
+      "version": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+    },
+    "array-differ": {
+      "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
+    "array-each": {
+      "version": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+    },
+    "array-equal": {
+      "version": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
+    "array-filter": {
+      "version": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+    },
+    "array-find-index": {
+      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "array-initial": {
+      "version": "https://registry.npmjs.org/array-initial/-/array-initial-1.0.1.tgz",
+      "integrity": "sha1-hhIiIqKcHtQjR/YzQRGvpA+LIOw=",
+      "requires": {
+        "array-slice": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
+      },
+      "dependencies": {
+        "array-slice": {
+          "version": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+          "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8="
+        },
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "array-last": {
+      "version": "https://registry.npmjs.org/array-last/-/array-last-1.1.1.tgz",
+      "integrity": "sha1-9GWPmI2SEya1itARPPdtM3x7IKo=",
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
+          "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY="
+        }
+      }
+    },
+    "array-map": {
+      "version": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+    },
+    "array-reduce": {
+      "version": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+    },
+    "array-slice": {
+      "version": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+    },
+    "array-sort": {
+      "version": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.3.tgz",
+      "integrity": "sha1-Qhza2cl1xMy9i2SZMzvyxtHtYns=",
+      "requires": {
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "array-union": {
+      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+      }
+    },
+    "array-uniq": {
+      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array-unique": {
+      "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "arraybuffer.slice": {
+      "version": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+    },
+    "arrayify-compact": {
+      "version": "https://registry.npmjs.org/arrayify-compact/-/arrayify-compact-0.2.0.tgz",
+      "integrity": "sha1-RZFw4VXKErtRRISDnJ1xUHyA7E0=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+      }
+    },
+    "arrify": {
+      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "asn1": {
+      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "asn1.js": {
+      "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
+    },
+    "assemble": {
+      "version": "https://registry.npmjs.org/assemble/-/assemble-0.24.3.tgz",
+      "integrity": "sha1-lSp3S3iAl6TW9Iw6QrpW9ouNZS8=",
+      "requires": {
+        "assemble-core": "https://registry.npmjs.org/assemble-core/-/assemble-core-0.31.0.tgz",
+        "assemble-loader": "https://registry.npmjs.org/assemble-loader/-/assemble-loader-1.0.5.tgz",
+        "base-argv": "https://registry.npmjs.org/base-argv/-/base-argv-0.5.0.tgz",
+        "base-cli-process": "https://registry.npmjs.org/base-cli-process/-/base-cli-process-0.1.19.tgz",
+        "base-config": "https://registry.npmjs.org/base-config/-/base-config-0.5.2.tgz",
+        "base-questions": "https://registry.npmjs.org/base-questions/-/base-questions-0.9.1.tgz",
+        "base-runtimes": "https://registry.npmjs.org/base-runtimes/-/base-runtimes-0.2.0.tgz",
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+        "engine-handlebars": "https://registry.npmjs.org/engine-handlebars/-/engine-handlebars-0.8.2.tgz",
+        "expand-front-matter": "https://registry.npmjs.org/expand-front-matter/-/expand-front-matter-1.0.0.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "parser-front-matter": "https://registry.npmjs.org/parser-front-matter/-/parser-front-matter-1.6.4.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz"
+      }
+    },
+    "assemble-core": {
+      "version": "https://registry.npmjs.org/assemble-core/-/assemble-core-0.31.0.tgz",
+      "integrity": "sha1-Rih0H2UX5/dJMYTDij44iPAlY+Q=",
+      "requires": {
+        "assemble-fs": "https://registry.npmjs.org/assemble-fs/-/assemble-fs-1.0.1.tgz",
+        "assemble-render-file": "https://registry.npmjs.org/assemble-render-file/-/assemble-render-file-1.0.3.tgz",
+        "assemble-streams": "https://registry.npmjs.org/assemble-streams/-/assemble-streams-1.0.1.tgz",
+        "base-task": "https://registry.npmjs.org/base-task/-/base-task-0.7.1.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "templates": "https://registry.npmjs.org/templates/-/templates-1.2.9.tgz"
+      }
+    },
+    "assemble-fs": {
+      "version": "https://registry.npmjs.org/assemble-fs/-/assemble-fs-1.0.1.tgz",
+      "integrity": "sha1-eAvMJ+itGVaqhQFyNEjjWcPdI88=",
+      "requires": {
+        "assemble-handle": "https://registry.npmjs.org/assemble-handle/-/assemble-handle-0.1.4.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "file-is-binary": "https://registry.npmjs.org/file-is-binary/-/file-is-binary-1.0.0.tgz",
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz"
+      }
+    },
+    "assemble-handle": {
+      "version": "https://registry.npmjs.org/assemble-handle/-/assemble-handle-0.1.4.tgz",
+      "integrity": "sha1-6De1uyPnXJsFJX2AfhYvaSzOIW4=",
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "assemble-loader": {
+      "version": "https://registry.npmjs.org/assemble-loader/-/assemble-loader-1.0.5.tgz",
+      "integrity": "sha1-qOplRNXsl/ljVrKeAIPwfUVx4Z8=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "file-contents": "https://registry.npmjs.org/file-contents/-/file-contents-1.0.1.tgz",
+        "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+        "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+        "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "load-templates": "https://registry.npmjs.org/load-templates/-/load-templates-1.0.2.tgz"
+      },
+      "dependencies": {
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              }
+            }
+          }
+        }
+      }
+    },
+    "assemble-render-file": {
+      "version": "https://registry.npmjs.org/assemble-render-file/-/assemble-render-file-1.0.3.tgz",
+      "integrity": "sha1-0vwcPUPp8nkE/xS4rOExvKLzzJ4=",
+      "requires": {
+        "async-array-reduce": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "file-is-binary": "https://registry.npmjs.org/file-is-binary/-/file-is-binary-1.0.0.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "plugin-error": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "assemble-streams": {
+      "version": "https://registry.npmjs.org/assemble-streams/-/assemble-streams-1.0.1.tgz",
+      "integrity": "sha1-pxrY0yscVovmkr++KmWgMWB6eGU=",
+      "requires": {
+        "assemble-handle": "https://registry.npmjs.org/assemble-handle/-/assemble-handle-0.1.4.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "match-file": "https://registry.npmjs.org/match-file/-/match-file-0.2.2.tgz",
+        "src-stream": "https://registry.npmjs.org/src-stream/-/src-stream-0.1.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "assert": {
+      "version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "requires": {
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      }
+    },
+    "assert-plus": {
+      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "assets": {
+      "version": "https://registry.npmjs.org/assets/-/assets-2.1.0.tgz",
+      "integrity": "sha1-v66YcXl01mY27tJrGOtxIGCIFvU=",
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+        "calipers": "https://registry.npmjs.org/calipers/-/calipers-2.0.0.tgz",
+        "calipers-gif": "https://registry.npmjs.org/calipers-gif/-/calipers-gif-2.0.0.tgz",
+        "calipers-jpeg": "https://registry.npmjs.org/calipers-jpeg/-/calipers-jpeg-2.0.0.tgz",
+        "calipers-png": "https://registry.npmjs.org/calipers-png/-/calipers-png-2.0.0.tgz",
+        "calipers-svg": "https://registry.npmjs.org/calipers-svg/-/calipers-svg-2.0.0.tgz",
+        "calipers-webp": "https://registry.npmjs.org/calipers-webp/-/calipers-webp-2.0.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "lodash": {
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "mime": {
+          "version": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+        }
+      }
+    },
+    "assign-deep": {
+      "version": "https://registry.npmjs.org/assign-deep/-/assign-deep-0.4.6.tgz",
+      "integrity": "sha1-IZKpiTVIQwk6A+/5QclHOpvFih0=",
+      "requires": {
+        "assign-symbols": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-0.1.1.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz"
+      }
+    },
+    "assign-symbols": {
+      "version": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-0.1.1.tgz",
+      "integrity": "sha1-ywJZRO9OyKNpPwhunhEsdOOg/tk="
+    },
+    "astw": {
+      "version": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+      }
+    },
+    "async": {
+      "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "async-array-reduce": {
+      "version": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+      "integrity": "sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE="
+    },
+    "async-done": {
+      "version": "https://registry.npmjs.org/async-done/-/async-done-1.2.3.tgz",
+      "integrity": "sha1-bHq8fWHKJ/5vHyujIG6prmCkOYM=",
+      "requires": {
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+        "stream-exhaust": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.1.tgz"
+      }
+    },
+    "async-each": {
+      "version": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "async-each-series": {
+      "version": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
+      "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg="
+    },
+    "async-foreach": {
+      "version": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+    },
+    "async-helpers": {
+      "version": "https://registry.npmjs.org/async-helpers/-/async-helpers-0.3.14.tgz",
+      "integrity": "sha1-Y9FMcoXURC9xve55LaR546qN0h4=",
+      "requires": {
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "safe-json-stringify": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "async-settle": {
+      "version": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "requires": {
+        "async-done": "https://registry.npmjs.org/async-done/-/async-done-1.2.3.tgz"
+      }
+    },
+    "asynckit": {
+      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
+    },
+    "autolinker": {
+      "version": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
+    },
+    "autoprefixer": {
+      "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.2.tgz",
+      "integrity": "sha1-++rwfUj9h44Ggr98vurecorbKxg=",
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.1.tgz",
+        "caniuse-lite": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
+        "normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+        "num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
+    },
+    "aws-sign2": {
+      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "babel-code-frame": {
+      "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+      }
+    },
+    "babel-core": {
+      "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+        "babel-helpers": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+      "requires": {
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "requires": {
+        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "requires": {
+        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-helpers": {
+      "version": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
+    },
+    "babel-jest": {
+      "version": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
+      "integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+        "babel-plugin-istanbul": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
+        "babel-preset-jest": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz"
+      }
+    },
+    "babel-messages": {
+      "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
+      "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+        "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
+          }
+        }
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
+      "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "requires": {
+        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+      "requires": {
+        "babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "requires": {
+        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "requires": {
+        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "requires": {
+        "babel-helper-call-delegate": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "requires": {
+        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "requires": {
+        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+      "requires": {
+        "regenerator-transform": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+        "babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+        "babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+        "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+        "babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+        "babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+        "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+        "babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+        "babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+        "babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+        "babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+        "babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+        "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+        "babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+        "babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+        "babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+        "babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+        "babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+        "babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
+      "integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+      "requires": {
+        "babel-plugin-jest-hoist": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz"
+      }
+    },
+    "babel-register": {
+      "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+        "home-or-tmp": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
+      }
+    },
+    "babel-runtime": {
+      "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+      "requires": {
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+      }
+    },
+    "babel-template": {
+      "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
+    },
+    "babel-traverse": {
+      "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
+    },
+    "babel-types": {
+      "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+      }
+    },
+    "babelify": {
+      "version": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "babylon": {
+      "version": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+      "integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo="
+    },
+    "bach": {
+      "version": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "requires": {
+        "arr-filter": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "arr-map": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+        "array-each": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+        "array-initial": "https://registry.npmjs.org/array-initial/-/array-initial-1.0.1.tgz",
+        "array-last": "https://registry.npmjs.org/array-last/-/array-last-1.1.1.tgz",
+        "async-done": "https://registry.npmjs.org/async-done/-/async-done-1.2.3.tgz",
+        "async-settle": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+        "now-and-later": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz"
+      }
+    },
+    "backo2": {
+      "version": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "balanced-match": {
+      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base": {
+      "version": "https://registry.npmjs.org/base/-/base-0.11.1.tgz",
+      "integrity": "sha1-s2p/ERE4U6NCoVaR2Y4tzIpswnA=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "cache-base": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
+        "class-utils": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-argv": {
+      "version": "https://registry.npmjs.org/base-argv/-/base-argv-0.5.0.tgz",
+      "integrity": "sha1-Ru4luprtVA6UUF2rHbKQXhqH2Fg=",
+      "requires": {
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-3.0.0.tgz",
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "expand-args": "https://registry.npmjs.org/expand-args/-/expand-args-0.4.3.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+        "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-3.0.0.tgz",
+          "integrity": "sha1-ORJuZE8dZ/R96S17cCjWCjeXYVI=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+          }
+        },
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
+          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-cli": {
+      "version": "https://registry.npmjs.org/base-cli/-/base-cli-0.5.0.tgz",
+      "integrity": "sha1-U+Zdjg9bKKoRBo/sjdTpXXLvPOg=",
+      "requires": {
+        "base-argv": "https://registry.npmjs.org/base-argv/-/base-argv-0.4.5.tgz",
+        "base-config": "https://registry.npmjs.org/base-config/-/base-config-0.5.2.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "base-argv": {
+          "version": "https://registry.npmjs.org/base-argv/-/base-argv-0.4.5.tgz",
+          "integrity": "sha1-BalXHNwnaUDeGW/8h07uuJnLED0=",
+          "requires": {
+            "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+            "expand-args": "https://registry.npmjs.org/expand-args/-/expand-args-0.4.3.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "base-cli-process": {
+      "version": "https://registry.npmjs.org/base-cli-process/-/base-cli-process-0.1.19.tgz",
+      "integrity": "sha1-Mg08gVTfcQltSBgY52/m1+R5NjY=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "arrayify-compact": "https://registry.npmjs.org/arrayify-compact/-/arrayify-compact-0.2.0.tgz",
+        "base-cli": "https://registry.npmjs.org/base-cli/-/base-cli-0.5.0.tgz",
+        "base-cli-schema": "https://registry.npmjs.org/base-cli-schema/-/base-cli-schema-0.1.19.tgz",
+        "base-config-process": "https://registry.npmjs.org/base-config-process/-/base-config-process-0.1.9.tgz",
+        "base-cwd": "https://registry.npmjs.org/base-cwd/-/base-cwd-0.3.4.tgz",
+        "base-option": "https://registry.npmjs.org/base-option/-/base-option-0.8.4.tgz",
+        "base-pkg": "https://registry.npmjs.org/base-pkg/-/base-pkg-0.2.5.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+        "merge-deep": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.0.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+        "pad-right": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+        "union-value": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "union-value": {
+          "version": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "requires": {
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz"
+          }
+        }
+      }
+    },
+    "base-cli-schema": {
+      "version": "https://registry.npmjs.org/base-cli-schema/-/base-cli-schema-0.1.19.tgz",
+      "integrity": "sha1-gfQYL0zwu4NnHxF2PknLBbkugkE=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "falsey": "https://registry.npmjs.org/falsey/-/falsey-0.3.0.tgz",
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "map-schema": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
+        "merge-deep": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.0.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+        "tableize-object": "https://registry.npmjs.org/tableize-object/-/tableize-object-0.1.0.tgz"
+      },
+      "dependencies": {
+        "has-glob": {
+          "version": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+          "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "base-config": {
+      "version": "https://registry.npmjs.org/base-config/-/base-config-0.5.2.tgz",
+      "integrity": "sha1-q2A8AdExWL4uYux3/7Ix4o9Ijh8=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+        "map-config": "https://registry.npmjs.org/map-config/-/map-config-0.5.0.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        },
+        "resolve-dir": {
+          "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "requires": {
+            "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+          }
+        }
+      }
+    },
+    "base-config-process": {
+      "version": "https://registry.npmjs.org/base-config-process/-/base-config-process-0.1.9.tgz",
+      "integrity": "sha1-imOmGYnuY1UMyM/cP2wCdf2gtG4=",
+      "requires": {
+        "base-config": "https://registry.npmjs.org/base-config/-/base-config-0.5.2.tgz",
+        "base-config-schema": "https://registry.npmjs.org/base-config-schema/-/base-config-schema-0.1.24.tgz",
+        "base-cwd": "https://registry.npmjs.org/base-cwd/-/base-cwd-0.3.4.tgz",
+        "base-option": "https://registry.npmjs.org/base-option/-/base-option-0.8.4.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-config-schema": {
+      "version": "https://registry.npmjs.org/base-config-schema/-/base-config-schema-0.1.24.tgz",
+      "integrity": "sha1-T74UvsVtwa7ef+3QaSjpGfhyH6k=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+        "base-pkg": "https://registry.npmjs.org/base-pkg/-/base-pkg-0.2.5.tgz",
+        "camel-case": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+        "inflection": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "load-templates": "https://registry.npmjs.org/load-templates/-/load-templates-1.0.2.tgz",
+        "map-schema": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
+        "matched": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-unique": {
+          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "define-property": {
+          "version": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz"
+          }
+        },
+        "expand-tilde": {
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "is-descriptor": {
+          "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+          "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
+          "requires": {
+            "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "kind-of": "5.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+              "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw=="
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "matched": {
+          "version": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+          "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
+          "requires": {
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "async-array-reduce": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+            "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+          },
+          "dependencies": {
+            "has-glob": {
+              "version": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+              "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
+              "requires": {
+                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+              }
+            }
+          }
+        },
+        "resolve-dir": {
+          "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "requires": {
+            "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+          }
+        }
+      }
+    },
+    "base-cwd": {
+      "version": "https://registry.npmjs.org/base-cwd/-/base-cwd-0.3.4.tgz",
+      "integrity": "sha1-TQCrY1CgRuGtSrnCMm2heUs+TwE=",
+      "requires": {
+        "empty-dir": "https://registry.npmjs.org/empty-dir/-/empty-dir-0.2.1.tgz",
+        "find-pkg": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-data": {
+      "version": "https://registry.npmjs.org/base-data/-/base-data-0.6.2.tgz",
+      "integrity": "sha1-AZ1xzyxmkdhfrp18iKXlSsaK5fs=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "cache-base": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+        "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "merge-value": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "read-file": "https://registry.npmjs.org/read-file/-/read-file-0.2.0.tgz",
+        "resolve-glob": "https://registry.npmjs.org/resolve-glob/-/resolve-glob-1.0.0.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+        "union-value": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "cache-base": {
+          "version": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+          "requires": {
+            "collection-visit": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "has-value": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "set-value": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "union-value": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "unset-value": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
+          }
+        },
+        "collection-visit": {
+          "version": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "requires": {
+            "map-visit": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+          }
+        },
+        "has-value": {
+          "version": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "requires": {
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "has-values": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          }
+        },
+        "has-values": {
+          "version": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "map-visit": {
+          "version": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "requires": {
+            "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+          }
+        },
+        "object-visit": {
+          "version": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "split-string": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz"
+          }
+        },
+        "union-value": {
+          "version": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "requires": {
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "set-value": "0.4.3"
+          },
+          "dependencies": {
+            "set-value": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "requires": {
+                "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+                "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+              }
+            }
+          }
+        },
+        "unset-value": {
+          "version": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "requires": {
+            "has-value": "0.3.1",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "requires": {
+                "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "requires": {
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+            }
+          }
+        }
+      }
+    },
+    "base-engines": {
+      "version": "https://registry.npmjs.org/base-engines/-/base-engines-0.2.1.tgz",
+      "integrity": "sha1-aXgAyoq4iKM3iXONv6zLgYoqWns=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "engine-cache": "https://registry.npmjs.org/engine-cache/-/engine-cache-0.19.4.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
+          "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
+          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-helpers": {
+      "version": "https://registry.npmjs.org/base-helpers/-/base-helpers-0.2.0.tgz",
+      "integrity": "sha1-dalJS7jAWf89eUOCnPdVBHv+ENc=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "load-helpers": "https://registry.npmjs.org/load-helpers/-/load-helpers-0.3.1.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              }
+            }
+          }
+        }
+      }
+    },
+    "base-option": {
+      "version": "https://registry.npmjs.org/base-option/-/base-option-0.8.4.tgz",
+      "integrity": "sha1-EUF/qSRPInpNU3tNKRcjRieH1cc=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "option-cache": "https://registry.npmjs.org/option-cache/-/option-cache-3.5.0.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz"
+          }
+        },
+        "to-object-path": {
+          "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
+          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "is-arguments": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "base-pkg": {
+      "version": "https://registry.npmjs.org/base-pkg/-/base-pkg-0.2.5.tgz",
+      "integrity": "sha1-fsLhP6fPKrgqzZmkEWhSxIiiymg=",
+      "requires": {
+        "cache-base": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+        "expand-pkg": "https://registry.npmjs.org/expand-pkg/-/expand-pkg-0.1.8.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+        "pkg-store": "https://registry.npmjs.org/pkg-store/-/pkg-store-0.2.2.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "cache-base": {
+          "version": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+          "requires": {
+            "collection-visit": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "has-value": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "set-value": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "union-value": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "unset-value": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
+          }
+        },
+        "collection-visit": {
+          "version": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "requires": {
+            "map-visit": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+          }
+        },
+        "define-property": {
+          "version": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz"
+          }
+        },
+        "has-value": {
+          "version": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "requires": {
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "has-values": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          }
+        },
+        "has-values": {
+          "version": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+          }
+        },
+        "is-descriptor": {
+          "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+          "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
+          "requires": {
+            "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "kind-of": "5.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+              "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw=="
+            }
+          }
+        },
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "map-visit": {
+          "version": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "requires": {
+            "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+          }
+        },
+        "object-visit": {
+          "version": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "split-string": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz"
+          }
+        },
+        "union-value": {
+          "version": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "requires": {
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "set-value": "0.4.3"
+          },
+          "dependencies": {
+            "set-value": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "requires": {
+                "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+                "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+              }
+            }
+          }
+        },
+        "unset-value": {
+          "version": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "requires": {
+            "has-value": "0.3.1",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "requires": {
+                "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "requires": {
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+            }
+          }
+        }
+      }
+    },
+    "base-plugins": {
+      "version": "https://registry.npmjs.org/base-plugins/-/base-plugins-0.4.13.tgz",
+      "integrity": "sha1-kd8XjcN/hoQt6ihteeSPuGtarD0=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-questions": {
+      "version": "https://registry.npmjs.org/base-questions/-/base-questions-0.9.1.tgz",
+      "integrity": "sha1-j/QX9ghiV2e+gCkn8fsR5daRQy4=",
+      "requires": {
+        "base-store": "https://registry.npmjs.org/base-store/-/base-store-0.4.4.tgz",
+        "clone-deep": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "question-store": "https://registry.npmjs.org/question-store/-/question-store-0.13.1.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-routes": {
+      "version": "https://registry.npmjs.org/base-routes/-/base-routes-0.2.2.tgz",
+      "integrity": "sha1-CmFNFy1JBF2Mk4dxP4YN88QFNB4=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "en-route": "https://registry.npmjs.org/en-route/-/en-route-0.7.5.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "template-error": "https://registry.npmjs.org/template-error/-/template-error-0.1.2.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-runtimes": {
+      "version": "https://registry.npmjs.org/base-runtimes/-/base-runtimes-0.2.0.tgz",
+      "integrity": "sha1-GI4+ZoJMyxWYsyh7TqW5NaG4UEU=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "time-diff": "https://registry.npmjs.org/time-diff/-/time-diff-0.3.1.tgz"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
+          "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
+          "requires": {
+            "ansi-bgblack": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
+            "ansi-bgblue": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
+            "ansi-bgcyan": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
+            "ansi-bggreen": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
+            "ansi-bgmagenta": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
+            "ansi-bgred": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
+            "ansi-bgwhite": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
+            "ansi-bgyellow": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
+            "ansi-black": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
+            "ansi-blue": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
+            "ansi-bold": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
+            "ansi-cyan": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "ansi-dim": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
+            "ansi-gray": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "ansi-green": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+            "ansi-grey": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
+            "ansi-hidden": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
+            "ansi-inverse": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
+            "ansi-italic": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
+            "ansi-magenta": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
+            "ansi-red": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "ansi-reset": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
+            "ansi-strikethrough": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
+            "ansi-underline": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
+            "ansi-white": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
+            "ansi-yellow": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+          },
+          "dependencies": {
+            "lazy-cache": {
+              "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+            }
+          }
+        },
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "log-utils": {
+          "version": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
+          "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
+          "requires": {
+            "ansi-colors": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
+            "error-symbol": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
+            "info-symbol": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
+            "log-ok": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+            "success-symbol": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+            "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "warning-symbol": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz"
+          }
+        }
+      }
+    },
+    "base-store": {
+      "version": "https://registry.npmjs.org/base-store/-/base-store-0.4.4.tgz",
+      "integrity": "sha1-JY32uKYu4G/xUADJSdD9fCi68mY=",
+      "requires": {
+        "data-store": "https://registry.npmjs.org/data-store/-/data-store-0.16.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+        "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "project-name": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz"
+      },
+      "dependencies": {
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
+          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "base-task": {
+      "version": "https://registry.npmjs.org/base-task/-/base-task-0.7.1.tgz",
+      "integrity": "sha1-m26qObA4CmHYMIpmVSV7CzghFCk=",
+      "requires": {
+        "composer": "https://registry.npmjs.org/composer/-/composer-0.14.2.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz"
+      }
+    },
+    "base64-arraybuffer": {
+      "version": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
+    "base64-js": {
+      "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY="
+    },
+    "base64id": {
+      "version": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8="
+    },
+    "batch": {
+      "version": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ="
+    },
+    "bcrypt-pbkdf": {
+      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      }
+    },
+    "beeper": {
+      "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+    },
+    "better-assert": {
+      "version": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+      }
+    },
+    "bin-build": {
+      "version": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
+      "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
+      "optional": true,
+      "requires": {
+        "archive-type": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
+        "decompress": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
+        "download": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
+        "exec-series": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "tempfile": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+        "url-regex": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz"
+      },
+      "dependencies": {
+        "tempfile": {
+          "version": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+          "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
+          "optional": true,
+          "requires": {
+            "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+          }
+        },
+        "uuid": {
+          "version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "optional": true
+        }
+      }
+    },
+    "bin-check": {
+      "version": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+      "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
+      "optional": true,
+      "requires": {
+        "executable": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
+      }
+    },
+    "bin-version": {
+      "version": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+      "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
+      "optional": true,
+      "requires": {
+        "find-versions": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz"
+      }
+    },
+    "bin-version-check": {
+      "version": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+      "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
+      "optional": true,
+      "requires": {
+        "bin-version": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+        "semver-truncate": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "optional": true
+        }
+      }
+    },
+    "bin-wrapper": {
+      "version": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+      "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
+      "optional": true,
+      "requires": {
+        "bin-check": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+        "bin-version-check": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+        "download": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
+        "each-async": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+        "lazy-req": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+        "os-filter-obj": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
+      }
+    },
+    "binary-extensions": {
+      "version": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
+      "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s="
+    },
+    "bindings": {
+      "version": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "bl": {
+      "version": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "blob": {
+      "version": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+    },
+    "block-stream": {
+      "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "bluebird": {
+      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+    },
+    "bn.js": {
+      "version": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
+    },
+    "boolbase": {
+      "version": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "boom": {
+      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
+    },
+    "boxen": {
+      "version": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "requires": {
+        "ansi-align": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cli-boxes": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+        "filled-array": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "widest-line": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      }
+    },
+    "braces": {
+      "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+        "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+      }
+    },
+    "brorand": {
+      "version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-pack": {
+      "version": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
+      "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
+      "requires": {
+        "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "umd": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+      }
+    },
+    "browser-resolve": {
+      "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "requires": {
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+        }
+      }
+    },
+    "browser-sync": {
+      "version": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
+      "integrity": "sha1-wo3D6zvmfJepBwgrdyo3+RXBTX0=",
+      "requires": {
+        "browser-sync-client": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
+        "browser-sync-ui": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
+        "bs-recipes": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+        "connect": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+        "dev-ip": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+        "easy-extender": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
+        "eazy-logger": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+        "emitter-steward": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
+        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+        "http-proxy": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+        "immutable": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+        "localtunnel": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "opn": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+        "portscanner": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+        "resp-modifier": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+        "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+        "serve-index": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
+        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
+        "server-destroy": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+        "socket.io": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
+        "socket.io-client": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+        "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+          }
+        },
+        "window-size": {
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+        },
+        "yargs": {
+          "version": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+          "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
+          }
+        },
+        "yargs-parser": {
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          }
+        }
+      }
+    },
+    "browser-sync-client": {
+      "version": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
+      "integrity": "sha1-7BrWmknC4tS2RbGLHAbCmz2a+Os=",
+      "requires": {
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+      }
+    },
+    "browser-sync-ui": {
+      "version": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
+      "integrity": "sha1-ZApTfBgGiTA9W+krxHa568RBwLw=",
+      "requires": {
+        "async-each-series": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+        "connect-history-api-fallback": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+        "immutable": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+        "server-destroy": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+        "stream-throttle": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+        "weinre": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz"
+      },
+      "dependencies": {
+        "async-each-series": {
+          "version": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+          "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
+        }
+      }
+    },
+    "browserify": {
+      "version": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
+      "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
+      "requires": {
+        "assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+        "browser-pack": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
+        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+        "buffer": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz",
+        "cached-path-relative": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+        "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+        "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+        "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "deps-sort": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+        "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+        "events": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "htmlescape": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+        "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "insert-module-globals": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "labeled-stream-splicer": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+        "module-deps": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+        "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+        "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+        "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+        "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+        "read-only-stream": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+        "shasum": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+        "shell-quote": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+        "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+        "stream-http": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+        "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+        "syntax-error": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+        "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+        "url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+        "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "browserify-aes": {
+      "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
+      "requires": {
+        "buffer-xor": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "browserify-cipher": {
+      "version": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "requires": {
+        "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+        "browserify-des": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+      }
+    },
+    "browserify-des": {
+      "version": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "requires": {
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "des.js": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "browserify-rsa": {
+      "version": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
+    },
+    "browserify-sign": {
+      "version": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
+      }
+    },
+    "browserify-zlib": {
+      "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "requires": {
+        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+      }
+    },
+    "browserslist": {
+      "version": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.1.tgz",
+      "integrity": "sha1-OVAKIJAzCyoJASDqbH/Hi24JHF4=",
+      "requires": {
+        "caniuse-lite": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
+        "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
+      }
+    },
+    "bs-recipes": {
+      "version": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
+    },
+    "bser": {
+      "version": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "requires": {
+        "node-int64": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
+      }
+    },
+    "buffer": {
+      "version": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz",
+      "integrity": "sha1-VwopC2Jc8mAykMEUkiPSfM8E25c=",
+      "requires": {
+        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+        "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+      }
+    },
+    "buffer-crc32": {
+      "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-to-vinyl": {
+      "version": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
+      "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
+      "requires": {
+        "file-type": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+        },
+        "uuid": {
+          "version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
+      }
+    },
+    "buffer-xor": {
+      "version": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "builtin-modules": {
+      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "builtin-status-codes": {
+      "version": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "cache-base": {
+      "version": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
+      "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
+      "requires": {
+        "collection-visit": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+        "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+        "union-value": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
+        "unset-value": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz"
+      }
+    },
+    "cached-path-relative": {
+      "version": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc="
+    },
+    "calipers": {
+      "version": "https://registry.npmjs.org/calipers/-/calipers-2.0.0.tgz",
+      "integrity": "sha1-vfIhxqYvYDuN3ZNAys2cecGgP84=",
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+      }
+    },
+    "calipers-gif": {
+      "version": "https://registry.npmjs.org/calipers-gif/-/calipers-gif-2.0.0.tgz",
+      "integrity": "sha1-te7+wwZKd8bc29W9xRc1oBuv3Dc=",
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+      }
+    },
+    "calipers-jpeg": {
+      "version": "https://registry.npmjs.org/calipers-jpeg/-/calipers-jpeg-2.0.0.tgz",
+      "integrity": "sha1-BtVqU/YnF92AnLlWz2RCPOaTRls=",
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+      }
+    },
+    "calipers-png": {
+      "version": "https://registry.npmjs.org/calipers-png/-/calipers-png-2.0.0.tgz",
+      "integrity": "sha1-HQ0g5cGuX3m3TVKGoul/Wbtwtlg=",
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+      }
+    },
+    "calipers-svg": {
+      "version": "https://registry.npmjs.org/calipers-svg/-/calipers-svg-2.0.0.tgz",
+      "integrity": "sha1-ZmJU1fHqZtIFLtgtbXm4vxCsu3E=",
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+      }
+    },
+    "calipers-webp": {
+      "version": "https://registry.npmjs.org/calipers-webp/-/calipers-webp-2.0.0.tgz",
+      "integrity": "sha1-4Sbs4vhM1xd5YSv6KyZTzZXOp3o=",
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+      }
+    },
+    "caller-path": {
+      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "requires": {
+        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+      }
+    },
+    "callsite": {
+      "version": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
+    "callsites": {
+      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+    },
+    "camel-case": {
+      "version": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
+        "upper-case": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+      }
+    },
+    "camelcase": {
+      "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+    },
+    "camelcase-keys": {
+      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
+    },
+    "caniuse-api": {
+      "version": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+        "lodash.memoize": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+        "lodash.uniq": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "requires": {
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
+          }
+        },
+        "lodash.memoize": {
+          "version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+          "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+        }
+      }
+    },
+    "caniuse-db": {
+      "version": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+      "integrity": "sha1-C5tceVlQ37rzAaiAa6/ofxJtqMo="
+    },
+    "caniuse-lite": {
+      "version": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
+      "integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA="
+    },
+    "capture-stack-trace": {
+      "version": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+    },
+    "caseless": {
+      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "caw": {
+      "version": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
+      "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
+      "requires": {
+        "get-proxy": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
+        "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        },
+        "tunnel-agent": {
+          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+        }
+      }
+    },
+    "center-align": {
+      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "chalk": {
+      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      }
+    },
+    "cheerio": {
+      "version": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "requires": {
+        "css-select": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+        "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+        "lodash.assignin": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+        "lodash.bind": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+        "lodash.filter": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+        "lodash.flatten": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+        "lodash.foreach": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+        "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+        "lodash.merge": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+        "lodash.pick": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+        "lodash.reduce": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+        "lodash.reject": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+        "lodash.some": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz"
+      },
+      "dependencies": {
+        "lodash.bind": {
+          "version": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+          "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+        }
+      }
+    },
+    "chokidar": {
+      "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "ci-info": {
+      "version": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ="
+    },
+    "cipher-base": {
+      "version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
+    },
+    "circular-json": {
+      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY="
+    },
+    "clap": {
+      "version": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+      "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      }
+    },
+    "class-utils": {
+      "version": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz",
+      "integrity": "sha1-F+eTEDdQ+WJ7IXbqNM/RtWWQPIA=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "static-extend": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        }
+      }
+    },
+    "cli-boxes": {
+      "version": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+    },
+    "cli-cursor": {
+      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "requires": {
+        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+      }
+    },
+    "cli-width": {
+      "version": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
+    },
+    "cliui": {
+      "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "requires": {
+        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+        }
+      }
+    },
+    "clone": {
+      "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+    },
+    "clone-buffer": {
+      "version": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+    },
+    "clone-deep": {
+      "version": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+      "requires": {
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+        "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+        "shallow-clone": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "clone-regexp": {
+      "version": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
+      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
+      "requires": {
+        "is-regexp": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+        "is-supported-regexp-flag": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz"
+      }
+    },
+    "clone-stats": {
+      "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+    },
+    "cloneable-readable": {
+      "version": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "co": {
+      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "coa": {
+      "version": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "code-point-at": {
+      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collection-visit": {
+      "version": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
+      "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
+      "requires": {
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "map-visit": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
+        "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz"
+      }
+    },
+    "color": {
+      "version": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+        "color-string": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
+      }
+    },
+    "color-convert": {
+      "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+      }
+    },
+    "color-diff": {
+      "version": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
+      "integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI="
+    },
+    "color-name": {
+      "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "requires": {
+        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+      }
+    },
+    "colorguard": {
+      "version": "https://registry.npmjs.org/colorguard/-/colorguard-1.2.0.tgz",
+      "integrity": "sha1-8/rK9cquuk71RlPZ+yW7cxd8DYQ=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "color-diff": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
+        "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pipetteur": "https://registry.npmjs.org/pipetteur/-/pipetteur-2.0.3.tgz",
+        "plur": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-reporter": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "postcss-reporter": {
+          "version": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
+          "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        },
+        "yargs": {
+          "version": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
+          "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo="
+        }
+      }
+    },
+    "colormin": {
+      "version": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+      "requires": {
+        "color": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+        "css-color-names": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+      }
+    },
+    "colors": {
+      "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "combine-source-map": {
+      "version": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+      "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+      "requires": {
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+        "inline-source-map": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+        "lodash.memoize": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      }
+    },
+    "commander": {
+      "version": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM="
+    },
+    "common-config": {
+      "version": "https://registry.npmjs.org/common-config/-/common-config-0.1.0.tgz",
+      "integrity": "sha1-0fGnQa+gy/al7wl1K9/C5nfYtO8=",
+      "requires": {
+        "composer": "https://registry.npmjs.org/composer/-/composer-0.13.0.tgz",
+        "data-store": "https://registry.npmjs.org/data-store/-/data-store-0.16.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+        "question-cache": "https://registry.npmjs.org/question-cache/-/question-cache-0.4.0.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+        "strip-color": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+        "tableize-object": "https://registry.npmjs.org/tableize-object/-/tableize-object-0.1.0.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "async-settle": {
+          "version": "https://registry.npmjs.org/async-settle/-/async-settle-0.2.1.tgz",
+          "integrity": "sha1-dnRi1XOACNx16sQkYiNSjyE3E5Y=",
+          "requires": {
+            "async-done": "https://registry.npmjs.org/async-done/-/async-done-0.4.0.tgz"
+          },
+          "dependencies": {
+            "async-done": {
+              "version": "https://registry.npmjs.org/async-done/-/async-done-0.4.0.tgz",
+              "integrity": "sha1-q4BT9fYikPi/xY83zZtzBwszB7k=",
+              "requires": {
+                "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+                "next-tick": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "stream-exhaust": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.1.tgz"
+              }
+            }
+          }
+        },
+        "bach": {
+          "version": "https://registry.npmjs.org/bach/-/bach-0.5.0.tgz",
+          "integrity": "sha1-P/pqN0F3PrwNJL5f2kvF6FtbHaE=",
+          "requires": {
+            "async-done": "https://registry.npmjs.org/async-done/-/async-done-1.2.3.tgz",
+            "async-settle": "https://registry.npmjs.org/async-settle/-/async-settle-0.2.1.tgz",
+            "lodash.filter": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+            "lodash.flatten": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "lodash.foreach": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+            "lodash.initial": "https://registry.npmjs.org/lodash.initial/-/lodash.initial-4.1.1.tgz",
+            "lodash.last": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+            "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+            "now-and-later": "https://registry.npmjs.org/now-and-later/-/now-and-later-0.0.6.tgz"
+          }
+        },
+        "composer": {
+          "version": "https://registry.npmjs.org/composer/-/composer-0.13.0.tgz",
+          "integrity": "sha1-HbyxXxmpBt7uSanD0TfmVLvG0OI=",
+          "requires": {
+            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "bach": "https://registry.npmjs.org/bach/-/bach-0.5.0.tgz",
+            "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "is-generator": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "nanoseconds": "https://registry.npmjs.org/nanoseconds/-/nanoseconds-0.1.0.tgz"
+          }
+        },
+        "end-of-stream": {
+          "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          },
+          "dependencies": {
+            "once": {
+              "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "requires": {
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "now-and-later": {
+          "version": "https://registry.npmjs.org/now-and-later/-/now-and-later-0.0.6.tgz",
+          "integrity": "sha1-GKFNw/xJXcBs++Ao8AvhbdrE+uo=",
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+          }
+        },
+        "question-cache": {
+          "version": "https://registry.npmjs.org/question-cache/-/question-cache-0.4.0.tgz",
+          "integrity": "sha1-4rmTf8X7fcYPu58QXx+iVLM96n0=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+            "inquirer2": "https://registry.npmjs.org/inquirer2/-/inquirer2-0.1.1.tgz",
+            "is-answer": "https://registry.npmjs.org/is-answer/-/is-answer-0.1.1.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+            "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.3.6.tgz",
+            "option-cache": "https://registry.npmjs.org/option-cache/-/option-cache-3.5.0.tgz",
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "project-name": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+            "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+            "to-choices": "https://registry.npmjs.org/to-choices/-/to-choices-0.2.0.tgz",
+            "use": "https://registry.npmjs.org/use/-/use-1.1.2.tgz"
+          },
+          "dependencies": {
+            "lazy-cache": {
+              "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+            },
+            "omit-empty": {
+              "version": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.3.6.tgz",
+              "integrity": "sha1-bThAXyqmHJEetQT+aIBcVm2FwxY=",
+              "requires": {
+                "has-values": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+                "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                "reduce-object": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz"
+              }
+            }
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz"
+          }
+        },
+        "to-object-path": {
+          "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
+          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "is-arguments": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "component-bind": {
+      "version": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
+    "component-emitter": {
+      "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "component-inherit": {
+      "version": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "composer": {
+      "version": "https://registry.npmjs.org/composer/-/composer-0.14.2.tgz",
+      "integrity": "sha1-ex11489plXnQKj6RX+XQvv6Yuac=",
+      "requires": {
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+        "bach": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-generator": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "nanoseconds": "https://registry.npmjs.org/nanoseconds/-/nanoseconds-0.1.0.tgz",
+        "pretty-time": "https://registry.npmjs.org/pretty-time/-/pretty-time-0.2.0.tgz"
+      },
+      "dependencies": {
+        "array-unique": {
+          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "define-property": {
+          "version": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz"
+          }
+        },
+        "is-descriptor": {
+          "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+          "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
+          "requires": {
+            "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz"
+          }
+        }
+      }
+    },
+    "concat-map": {
+      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "configstore": {
+      "version": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "requires": {
+        "dot-prop": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+        "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+        "xdg-basedir": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
+      }
+    },
+    "connect": {
+      "version": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+      "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+      "integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk="
+    },
+    "console-browserify": {
+      "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "requires": {
+        "date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+      }
+    },
+    "console-control-strings": {
+      "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "console-stream": {
+      "version": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
+      "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ=",
+      "optional": true
+    },
+    "constants-browserify": {
+      "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+    },
+    "contains-path": {
+      "version": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+    },
+    "content-type-parser": {
+      "version": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
+    },
+    "convert-source-map": {
+      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+    },
+    "cookie": {
+      "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "copy-descriptor": {
+      "version": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-js": {
+      "version": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+    },
+    "core-util-is": {
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "integrity": "sha1-YXPOvVb6wELB9DkO33r2wHx8uJI=",
+      "requires": {
+        "is-directory": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+        "require-from-string": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
+      }
+    },
+    "create-ecdh": {
+      "version": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+      }
+    },
+    "create-error-class": {
+      "version": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "requires": {
+        "capture-stack-trace": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
+      }
+    },
+    "create-frame": {
+      "version": "https://registry.npmjs.org/create-frame/-/create-frame-1.0.0.tgz",
+      "integrity": "sha1-i5XyaR4ySbYIBEPjPQutn49pdao=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+      }
+    },
+    "create-hash": {
+      "version": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+      "requires": {
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      }
+    },
+    "create-hmac": {
+      "version": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+      "requires": {
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      }
+    },
+    "cross-spawn": {
+      "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+        "shebang-command": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+      }
+    },
+    "cryptiles": {
+      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      }
+    },
+    "crypto-browserify": {
+      "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha1-lIlF78Z1ekANbl5a9HGU0QBkJ58=",
+      "requires": {
+        "browserify-cipher": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+        "browserify-sign": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+        "create-ecdh": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "diffie-hellman": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+        "public-encrypt": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
+    },
+    "css": {
+      "version": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+        "source-map-resolve": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+        "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "css-color-names": {
+      "version": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+    },
+    "css-rule-stream": {
+      "version": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
+      "integrity": "sha1-N4bnGYmD2WWibjGVfgkHjLt3BaI=",
+      "requires": {
+        "css-tokenize": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+        "ldjson-stream": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+          }
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              }
+            }
+          }
+        }
+      }
+    },
+    "css-select": {
+      "version": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+        "css-what": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+        "nth-check": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+      }
+    },
+    "css-tokenize": {
+      "version": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
+      "integrity": "sha1-RiXLHtohwUOFi3+B1oA8HSb8FL4=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "css-what": {
+      "version": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+    },
+    "cssnano": {
+      "version": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+      "requires": {
+        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-calc": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+        "postcss-colormin": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+        "postcss-convert-values": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+        "postcss-discard-comments": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+        "postcss-discard-duplicates": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+        "postcss-discard-empty": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+        "postcss-discard-overridden": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+        "postcss-discard-unused": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+        "postcss-filter-plugins": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+        "postcss-merge-idents": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+        "postcss-merge-longhand": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+        "postcss-merge-rules": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+        "postcss-minify-font-values": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+        "postcss-minify-gradients": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+        "postcss-minify-params": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+        "postcss-minify-selectors": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+        "postcss-normalize-charset": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+        "postcss-normalize-url": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+        "postcss-ordered-values": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+        "postcss-reduce-idents": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+        "postcss-reduce-initial": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+        "postcss-reduce-transforms": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+        "postcss-svgo": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+        "postcss-unique-selectors": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "postcss-zindex": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz"
+      },
+      "dependencies": {
+        "autoprefixer": {
+          "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+          "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+          "requires": {
+            "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+            "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+          }
+        },
+        "browserslist": {
+          "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "requires": {
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
+          }
+        },
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "csso": {
+      "version": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+      "requires": {
+        "clap": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "cssom": {
+      "version": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+    },
+    "cssstyle": {
+      "version": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "requires": {
+        "cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
+      }
+    },
+    "currently-unhandled": {
+      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+      }
+    },
+    "cwd": {
+      "version": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
+      "integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
+      "requires": {
+        "find-pkg": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz"
+      }
+    },
+    "d": {
+      "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz"
+      }
+    },
+    "dashdash": {
+      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "data-store": {
+      "version": "https://registry.npmjs.org/data-store/-/data-store-0.16.1.tgz",
+      "integrity": "sha1-5pwDpcrBXR/zPwJUyWeDZT5ogwQ=",
+      "requires": {
+        "cache-base": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
+        "clone-deep": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "has-own-deep": "https://registry.npmjs.org/has-own-deep/-/has-own-deep-0.1.4.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "project-name": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "union-value": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
+        },
+        "resolve-dir": {
+          "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "requires": {
+            "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+          }
+        }
+      }
+    },
+    "date-now": {
+      "version": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+    },
+    "date.js": {
+      "version": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
+      "integrity": "sha1-OefHx3rcdl0Qvs9JbKzTkTMtfMg=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+        "lodash.filter": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+        "lodash.findkey": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
+        "lodash.foreach": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+        "lodash.includes": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+        "lodash.isempty": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+        "lodash.partition": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+        "lodash.trim": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        }
+      }
+    },
+    "dateformat": {
+      "version": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
+    },
+    "deasync": {
+      "version": "https://registry.npmjs.org/deasync/-/deasync-0.1.10.tgz",
+      "integrity": "sha1-TkpoNvvgR3vV+Qgwi9KpZVfV1/4=",
+      "requires": {
+        "bindings": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+        "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+      }
+    },
+    "debug": {
+      "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "requires": {
+        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+      }
+    },
+    "debug-fabulous": {
+      "version": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.1.1.tgz",
+      "integrity": "sha1-G5cIeMn6T70ciDBuqzI8gwxY8dY=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.0.tgz",
+        "memoizee": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.5.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.0.tgz",
+          "integrity": "sha1-ORLcVdcWf8OvF9K4XBP5PertqkM=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        },
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+        }
+      }
+    },
+    "decamelize": {
+      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decompress": {
+      "version": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
+      "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
+      "requires": {
+        "buffer-to-vinyl": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+        "decompress-tar": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+        "decompress-tarbz2": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+        "decompress-targz": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+        "decompress-unzip": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
+        "stream-combiner2": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+        "vinyl-assign": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz"
+      }
+    },
+    "decompress-tar": {
+      "version": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+      "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
+      "requires": {
+        "is-tar": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+        "strip-dirs": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+        "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
+        }
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+      "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
+      "requires": {
+        "is-bzip2": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+        "seek-bzip": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+        "strip-dirs": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+        "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+      "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
+      "requires": {
+        "is-gzip": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+        "strip-dirs": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+        "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
+      "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
+      "requires": {
+        "is-zip": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
+        "read-all-stream": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+        "stat-mode": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+        "strip-dirs": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz"
+      }
+    },
+    "deep-bind": {
+      "version": "https://registry.npmjs.org/deep-bind/-/deep-bind-0.3.0.tgz",
+      "integrity": "sha1-lcMd2Eoc0bOBEZosQu25DbSFvDM=",
+      "requires": {
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz"
+      }
+    },
+    "deep-extend": {
+      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deep-is": {
+      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "default-require-extensions": {
+      "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+      "requires": {
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      }
+    },
+    "defaults": {
+      "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+      }
+    },
+    "define-property": {
+      "version": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "requires": {
+        "is-descriptor": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz"
+      }
+    },
+    "defined": {
+      "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "del": {
+      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "requires": {
+        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+      }
+    },
+    "delayed-stream": {
+      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "delimiter-regex": {
+      "version": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-2.0.0.tgz",
+      "integrity": "sha1-DQ9vYdmRVZH9Qwh6jpWF0+IRWnU=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        }
+      }
+    },
+    "depd": {
+      "version": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+    },
+    "deprecated": {
+      "version": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
+    },
+    "deps-sort": {
+      "version": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+      "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "shasum": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+        "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "des.js": {
+      "version": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
+    },
+    "destroy": {
+      "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-file": {
+      "version": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+      "requires": {
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
+      }
+    },
+    "detect-indent": {
+      "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+      }
+    },
+    "detect-newline": {
+      "version": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+    },
+    "detective": {
+      "version": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+      }
+    },
+    "dev-ip": {
+      "version": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+      "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
+    },
+    "diff": {
+      "version": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
+      "integrity": "sha1-BWaVFQ16qTI3yn43isOxaCt5Y7k="
+    },
+    "diffie-hellman": {
+      "version": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "miller-rabin": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
+    },
+    "doctrine": {
+      "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "requires": {
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      }
+    },
+    "doiuse": {
+      "version": "https://registry.npmjs.org/doiuse/-/doiuse-2.6.0.tgz",
+      "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+        "css-rule-stream": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+        "jsonfilter": "https://registry.npmjs.org/jsonfilter/-/jsonfilter-1.1.2.tgz",
+        "ldjson-stream": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "requires": {
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
+          }
+        },
+        "duplexer2": {
+          "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+          }
+        },
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              }
+            }
+          }
+        }
+      }
+    },
+    "dom-serializer": {
+      "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "requires": {
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "dom-urls": {
+      "version": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+      "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
+      "requires": {
+        "urijs": "https://registry.npmjs.org/urijs/-/urijs-1.18.12.tgz"
+      }
+    },
+    "domain-browser": {
+      "version": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+    },
+    "domelementtype": {
+      "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    },
+    "domhandler": {
+      "version": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "requires": {
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+      }
+    },
+    "domutils": {
+      "version": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+      }
+    },
+    "dot-prop": {
+      "version": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "requires": {
+        "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+      }
+    },
+    "download": {
+      "version": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
+      "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
+      "requires": {
+        "caw": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+        "each-async": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+        "filenamify": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+        "got": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+        "gulp-decompress": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
+        "gulp-rename": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+        "is-url": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "read-all-stream": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "stream-combiner2": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+        "ware": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz"
+      }
+    },
+    "duplexer": {
+      "version": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "duplexer2": {
+      "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "duplexify": {
+      "version": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+      "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
+      "requires": {
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "stream-shift": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+      }
+    },
+    "each-async": {
+      "version": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+      "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+      "requires": {
+        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+      }
+    },
+    "easy-extender": {
+      "version": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
+      "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
+      "requires": {
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
+    },
+    "eazy-logger": {
+      "version": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+      "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
+      "requires": {
+        "tfunk": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+      }
+    },
+    "ee-first": {
+      "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "electron-to-chromium": {
+      "version": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+      "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw="
+    },
+    "elliptic": {
+      "version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+        "hmac-drbg": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+        "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+      }
+    },
+    "emitter-steward": {
+      "version": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
+      "integrity": "sha1-80Ea3pdYp1Zd+Eiy2gy70bRsvWQ="
+    },
+    "empty-dir": {
+      "version": "https://registry.npmjs.org/empty-dir/-/empty-dir-0.2.1.tgz",
+      "integrity": "sha1-gJ7kih60rRy1EMJXLWb9DthNAas=",
+      "requires": {
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
+      }
+    },
+    "en-route": {
+      "version": "https://registry.npmjs.org/en-route/-/en-route-0.7.5.tgz",
+      "integrity": "sha1-6CMOc4NsXpXGdX4EQtPBExJL3Zg=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "encodeurl": {
+      "version": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
+    "end-of-stream": {
+      "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      }
+    },
+    "engine": {
+      "version": "https://registry.npmjs.org/engine/-/engine-0.1.12.tgz",
+      "integrity": "sha1-+H6MkLuAzT9YWXrFaVk+5G2idC0=",
+      "requires": {
+        "assign-deep": "https://registry.npmjs.org/assign-deep/-/assign-deep-0.4.6.tgz",
+        "collection-visit": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz"
+      },
+      "dependencies": {
+        "get-value": {
+          "version": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+            "noncharacters": "https://registry.npmjs.org/noncharacters/-/noncharacters-1.1.0.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o="
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
+          "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+            "noncharacters": "https://registry.npmjs.org/noncharacters/-/noncharacters-1.1.0.tgz"
+          }
+        }
+      }
+    },
+    "engine-base": {
+      "version": "https://registry.npmjs.org/engine-base/-/engine-base-0.1.3.tgz",
+      "integrity": "sha1-1ZycxS591t0rSa579ftEmU9wFqU=",
+      "requires": {
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "delimiter-regex": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-2.0.0.tgz",
+        "engine": "https://registry.npmjs.org/engine/-/engine-0.1.12.tgz",
+        "engine-utils": "https://registry.npmjs.org/engine-utils/-/engine-utils-0.1.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz"
+      }
+    },
+    "engine-cache": {
+      "version": "https://registry.npmjs.org/engine-cache/-/engine-cache-0.19.4.tgz",
+      "integrity": "sha1-giSWb732pl54Dsed+HtrLLgjlbI=",
+      "requires": {
+        "async-helpers": "https://registry.npmjs.org/async-helpers/-/async-helpers-0.3.14.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "helper-cache": "https://registry.npmjs.org/helper-cache/-/helper-cache-0.7.2.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz"
+      }
+    },
+    "engine-handlebars": {
+      "version": "https://registry.npmjs.org/engine-handlebars/-/engine-handlebars-0.8.2.tgz",
+      "integrity": "sha1-qnCdhpSdNTMaFdZQAj2cvkIVqfk=",
+      "requires": {
+        "engine-utils": "https://registry.npmjs.org/engine-utils/-/engine-utils-0.1.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
+      }
+    },
+    "engine-utils": {
+      "version": "https://registry.npmjs.org/engine-utils/-/engine-utils-0.1.1.tgz",
+      "integrity": "sha1-rd9HCN2FoFoyF6l3l+q4oBPE+A4="
+    },
+    "engine.io": {
+      "version": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
+      "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+        "base64id": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-parser": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+        "ws": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
+      "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
+      "requires": {
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "component-inherit": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-parser": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+        "has-cors": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "parsejson": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+        "parseqs": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+        "parseuri": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+        "ws": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+        "xmlhttprequest-ssl": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+        "yeast": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+      "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
+      "requires": {
+        "after": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+        "arraybuffer.slice": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+        "base64-arraybuffer": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+        "blob": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+        "wtf-8": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
+      },
+      "dependencies": {
+        "has-binary": {
+          "version": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+          "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          }
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
+    "ent": {
+      "version": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+    },
+    "entities": {
+      "version": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "errno": {
+      "version": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "requires": {
+        "prr": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+      }
+    },
+    "error-ex": {
+      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      }
+    },
+    "error-symbol": {
+      "version": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
+      "integrity": "sha1-Ck2uN9YA0VopukU9jvkg8YRDM/Y="
+    },
+    "es5-ext": {
+      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+      "integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+      "requires": {
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+      }
+    },
+    "es6-iterator": {
+      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+      }
+    },
+    "es6-promise": {
+      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha1-iBHpCRXZoNujYnTwskLb2nj5ySo="
+    },
+    "es6-symbol": {
+      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz"
+      }
+    },
+    "es6-weak-map": {
+      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+      }
+    },
+    "escape-html": {
+      "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "requires": {
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        },
+        "estraverse": {
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "optional": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "eslint": {
+      "version": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+      "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+      "requires": {
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+        "eslint-scope": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+        "espree": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+        "esquery": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+        "functional-red-black-tree": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+        "table": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+          "requires": {
+            "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "fast-deep-equal": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+            "json-schema-traverse": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+          }
+        },
+        "concat-stream": {
+          "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz",
+      "integrity": "sha1-wKsQjJvu1QPLmZ5MYPTvmO2g7TA=",
+      "requires": {
+        "eslint-restricted-globals": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+      "integrity": "sha1-RCJXTN5mqaewmZOO5NUIoZng48w=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+      "integrity": "sha1-Id4zOAue+1X1720uIQ7A4H5/pp8=",
+      "requires": {
+        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+        "contains-path": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+        "eslint-import-resolver-node": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+        "eslint-module-utils": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "lodash.cond": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "requires": {
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "find-up": {
+          "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
+          }
+        },
+        "load-json-file": {
+          "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+          }
+        },
+        "path-type": {
+          "version": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "requires": {
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+          }
+        },
+        "read-pkg": {
+          "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "requires": {
+            "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "path-type": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
+          }
+        },
+        "read-pkg-up": {
+          "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "requires": {
+            "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+          }
+        },
+        "strip-bom": {
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz",
+      "integrity": "sha1-7BXrpqwKtEpn6/bgJnLKnX58uik="
+    },
+    "eslint-restricted-globals": {
+      "version": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc="
+    },
+    "eslint-scope": {
+      "version": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "requires": {
+        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+      }
+    },
+    "espree": {
+      "version": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "integrity": "sha1-U/4WERH5EquZnuiHqQoLxSgi/XU="
+        }
+      }
+    },
+    "esprima": {
+      "version": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+    },
+    "esquery": {
+      "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "requires": {
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+      }
+    },
+    "esrecurse": {
+      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "requires": {
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "estraverse": {
+      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+    },
+    "esutils": {
+      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "etag": {
+      "version": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+    },
+    "event-emitter": {
+      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz"
+      }
+    },
+    "eventemitter3": {
+      "version": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+    },
+    "events": {
+      "version": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "evp_bytestokey": {
+      "version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+      "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
+      "requires": {
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz"
+      }
+    },
+    "exec-buffer": {
+      "version": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+      "integrity": "sha1-sWhtvZBMfPmC5lLB9aebHlVzCCs=",
+      "optional": true,
+      "requires": {
+        "execa": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+        "p-finally": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "tempfile": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "optional": true
+        }
+      }
+    },
+    "exec-series": {
+      "version": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
+      "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
+      "optional": true,
+      "requires": {
+        "async-each-series": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "exec-sh": {
+      "version": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
+      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+      "requires": {
+        "merge": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+      }
+    },
+    "execa": {
+      "version": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "optional": true,
+      "requires": {
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+        "get-stream": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+        "npm-run-path": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+        "p-finally": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+        "strip-eof": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
+      }
+    },
+    "execall": {
+      "version": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "requires": {
+        "clone-regexp": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz"
+      }
+    },
+    "executable": {
+      "version": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
+      "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
+      "optional": true,
+      "requires": {
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+      }
+    },
+    "exit-hook": {
+      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "exorcist": {
+      "version": "https://registry.npmjs.org/exorcist/-/exorcist-0.4.0.tgz",
+      "integrity": "sha1-EjD/3t2SSPQvvM+LSkTUyrKePGQ=",
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+        "mold-source-map": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
+        "nave": "https://registry.npmjs.org/nave/-/nave-0.5.3.tgz"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
+        }
+      }
+    },
+    "expand": {
+      "version": "https://registry.npmjs.org/expand/-/expand-0.5.0.tgz",
+      "integrity": "sha1-RSbjOcnkqs4dIE0I+B/m9Pp5LbY=",
+      "requires": {
+        "engine": "https://registry.npmjs.org/engine/-/engine-0.1.12.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "regex-flags": "https://registry.npmjs.org/regex-flags/-/regex-flags-0.1.0.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "expand-args": {
+      "version": "https://registry.npmjs.org/expand-args/-/expand-args-0.4.3.tgz",
+      "integrity": "sha1-OoZiJBxYF1fIzTf7d2d6xgL/nZg=",
+      "requires": {
+        "expand-object": "https://registry.npmjs.org/expand-object/-/expand-object-0.4.2.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz"
+          }
+        },
+        "to-object-path": {
+          "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
+          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "is-arguments": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "expand-brackets": {
+      "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+      }
+    },
+    "expand-front-matter": {
+      "version": "https://registry.npmjs.org/expand-front-matter/-/expand-front-matter-1.0.0.tgz",
+      "integrity": "sha1-gjHKjY669r9rCPa04GQg01rKAmg=",
+      "requires": {
+        "expand": "https://registry.npmjs.org/expand/-/expand-0.4.3.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz"
+      },
+      "dependencies": {
+        "expand": {
+          "version": "https://registry.npmjs.org/expand/-/expand-0.4.3.tgz",
+          "integrity": "sha1-0HawaUWkGp3h9+FRsiVMtz6IXVA=",
+          "requires": {
+            "engine": "https://registry.npmjs.org/engine/-/engine-0.1.12.tgz",
+            "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "regex-flags": "https://registry.npmjs.org/regex-flags/-/regex-flags-0.1.0.tgz"
+          }
+        },
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "expand-object": {
+      "version": "https://registry.npmjs.org/expand-object/-/expand-object-0.4.2.tgz",
+      "integrity": "sha1-t/J+9pwv3MYrD5OQwMtHvAa7Buo=",
+      "requires": {
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz"
+          }
+        },
+        "to-object-path": {
+          "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
+          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "is-arguments": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "expand-pkg": {
+      "version": "https://registry.npmjs.org/expand-pkg/-/expand-pkg-0.1.8.tgz",
+      "integrity": "sha1-JhIwIzQMvABiBsujm4Kh0XbD9oc=",
+      "requires": {
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "load-pkg": "https://registry.npmjs.org/load-pkg/-/load-pkg-3.0.1.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "normalize-pkg": "https://registry.npmjs.org/normalize-pkg/-/normalize-pkg-0.3.20.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+        "parse-author": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
+        "parse-git-config": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+        "repo-utils": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "expand-range": {
+      "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+      }
+    },
+    "expand-tilde": {
+      "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "requires": {
+        "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
+      }
+    },
+    "export-files": {
+      "version": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+      "integrity": "sha1-u/ZFdAU6CeTrmOX0NQHVcrLDzn8=",
+      "requires": {
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "express": {
+      "version": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+      "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
+      "requires": {
+        "connect": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+      },
+      "dependencies": {
+        "connect": {
+          "version": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+          "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
+          "requires": {
+            "formidable": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+            "mime": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+          }
+        },
+        "mkdirp": {
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+        },
+        "qs": {
+          "version": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
+          "integrity": "sha1-PKxMhh43GoycR3CsI82o3mObjl8="
+        }
+      }
+    },
+    "ext-map": {
+      "version": "https://registry.npmjs.org/ext-map/-/ext-map-1.0.1.tgz",
+      "integrity": "sha1-H82FcTVpS7Ip+9zPJhTbYNgT4FE="
+    },
+    "extend": {
+      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extend-shallow": {
+      "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "requires": {
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      }
+    },
+    "external-editor": {
+      "version": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
+      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "requires": {
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+        "jschardet": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+        "tmp": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz"
+      }
+    },
+    "extglob": {
+      "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "eyeglass": {
+      "version": "https://registry.npmjs.org/eyeglass/-/eyeglass-1.2.1.tgz",
+      "integrity": "sha1-aMEqYLBug1iXKrw2R54qnzZOatc=",
+      "requires": {
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "deasync": "https://registry.npmjs.org/deasync/-/deasync-0.1.10.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "lodash.includes": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+        "lodash.merge": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+        "node-sass": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+        "node-sass-utils": "https://registry.npmjs.org/node-sass-utils/-/node-sass-utils-1.1.2.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "jsonfile": {
+          "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          }
+        }
+      }
+    },
+    "falsey": {
+      "version": "https://registry.npmjs.org/falsey/-/falsey-0.3.0.tgz",
+      "integrity": "sha1-2p+dh1QvmlJ/g9jHYWudCpWfTvg=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "fancy-log": {
+      "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-levenshtein": {
+      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fb-watchman": {
+      "version": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "requires": {
+        "bser": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz"
+      }
+    },
+    "fd-slicer": {
+      "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+      }
+    },
+    "figures": {
+      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "requires": {
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "file-contents": {
+      "version": "https://registry.npmjs.org/file-contents/-/file-contents-1.0.1.tgz",
+      "integrity": "sha1-ryW7/T00RjhPrYBmSdiAi8/uHsg=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "strip-bom-buffer": "https://registry.npmjs.org/strip-bom-buffer/-/strip-bom-buffer-0.1.1.tgz",
+        "strip-bom-string": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-0.1.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "file-entry-cache": {
+      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "requires": {
+        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "file-is-binary": {
+      "version": "https://registry.npmjs.org/file-is-binary/-/file-is-binary-1.0.0.tgz",
+      "integrity": "sha1-XkGAbRvK5FjI/sMv484SLbu8Q1Y=",
+      "requires": {
+        "is-binary-buffer": "https://registry.npmjs.org/is-binary-buffer/-/is-binary-buffer-1.0.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+      }
+    },
+    "file-name": {
+      "version": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
+      "integrity": "sha1-ErEi8SD5w028F2wauBpUis7W3vc="
+    },
+    "file-type": {
+      "version": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+      "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
+    },
+    "filename-regex": {
+      "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "filename-reserved-regex": {
+      "version": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
+    },
+    "filenamify": {
+      "version": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "requires": {
+        "filename-reserved-regex": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+        "strip-outer": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+        "trim-repeated": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
+      }
+    },
+    "fileset": {
+      "version": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "filesizegzip": {
+      "version": "https://registry.npmjs.org/filesizegzip/-/filesizegzip-2.0.0.tgz",
+      "integrity": "sha1-qmmFiqGKhz8ZYOswtMbY1nCfSUk=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "gzip-size": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+        "pretty-bytes": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz"
+      }
+    },
+    "fill-range": {
+      "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "filled-array": {
+      "version": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
+    },
+    "finalhandler": {
+      "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+      "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "find-file-up": {
+      "version": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+      "requires": {
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
+        },
+        "resolve-dir": {
+          "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "requires": {
+            "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+          }
+        }
+      }
+    },
+    "find-index": {
+      "version": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+    },
+    "find-pkg": {
+      "version": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+      "requires": {
+        "find-file-up": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz"
+      }
+    },
+    "find-up": {
+      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
+    },
+    "find-versions": {
+      "version": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
+      "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
+      "optional": true,
+      "requires": {
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "semver-regex": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "optional": true
+        }
+      }
+    },
+    "findup-sync": {
+      "version": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+      "requires": {
+        "detect-file": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        },
+        "resolve-dir": {
+          "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "requires": {
+            "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+          }
+        }
+      }
+    },
+    "fined": {
+      "version": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "requires": {
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+        "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+        "object.defaults": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+        "parse-filepath": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz"
+      }
+    },
+    "first-chunk-stream": {
+      "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+    },
+    "flagged-respawn": {
+      "version": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU="
+    },
+    "flat-cache": {
+      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "requires": {
+        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+      }
+    },
+    "flatten": {
+      "version": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+    },
+    "follow-redirects": {
+      "version": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+      "optional": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "stream-consume": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+      }
+    },
+    "for-in": {
+      "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+      }
+    },
+    "forever-agent": {
+      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "fork-stream": {
+      "version": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA="
+    },
+    "form-data": {
+      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "requires": {
+        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
+      }
+    },
+    "formidable": {
+      "version": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+      "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
+    },
+    "fragment-cache": {
+      "version": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
+      }
+    },
+    "fresh": {
+      "version": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+    },
+    "fs-exists-sync": {
+      "version": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+    },
+    "fs-extra": {
+      "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+        "universalify": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz"
+      }
+    },
+    "fs.realpath": {
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+      }
+    },
+    "function-bind": {
+      "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+    },
+    "functional-red-black-tree": {
+      "version": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "gather-stream": {
+      "version": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz",
+      "integrity": "sha1-szmUr0V6gRVwDUEPMXczy+egkEs="
+    },
+    "gauge": {
+      "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+      }
+    },
+    "gaze": {
+      "version": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "requires": {
+        "globule": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz"
+      }
+    },
+    "get-caller-file": {
+      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+    },
+    "get-object": {
+      "version": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
+      "integrity": "sha1-2S/31RkMZFMM2gVD2sY6PUf+jAw=",
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+          "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4="
+        }
+      }
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-1.0.1.tgz",
+      "integrity": "sha1-8dTjrRQC4DmJjlbR6bmqkkwm5IQ="
+    },
+    "get-proxy": {
+      "version": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
+      "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
+      "requires": {
+        "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz"
+      }
+    },
+    "get-stdin": {
+      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+    },
+    "get-stream": {
+      "version": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "optional": true
+    },
+    "get-value": {
+      "version": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "get-view": {
+      "version": "https://registry.npmjs.org/get-view/-/get-view-0.1.3.tgz",
+      "integrity": "sha1-NmCsBYuhPfl0nKvKpry5bUGqDqA=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "match-file": "https://registry.npmjs.org/match-file/-/match-file-0.2.2.tgz"
+      }
+    },
+    "getpass": {
+      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "gifsicle": {
+      "version": "https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.4.tgz",
+      "integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
+      "optional": true,
+      "requires": {
+        "bin-build": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
+        "bin-wrapper": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+        "logalot": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz"
+      }
+    },
+    "git-config-path": {
+      "version": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
+      }
+    },
+    "git-repo-name": {
+      "version": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
+      "integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
+      "requires": {
+        "cwd": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
+        "file-name": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+        "remote-origin-url": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.3.tgz"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "github": {
+      "version": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
+      "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw=",
+      "optional": true,
+      "requires": {
+        "follow-redirects": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+        "https-proxy-agent": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+        "netrc": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
+          "optional": true
+        }
+      }
+    },
+    "glob": {
+      "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "requires": {
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      }
+    },
+    "glob-base": {
+      "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "requires": {
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+        "path-dirname": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+      }
+    },
+    "glob-stream": {
+      "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+      "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+      "requires": {
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "to-absolute-glob": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+        "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+      "requires": {
+        "gaze": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
+      },
+      "dependencies": {
+        "gaze": {
+          "version": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+          "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+          "requires": {
+            "globule": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+          }
+        },
+        "globule": {
+          "version": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+          "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+          }
+        },
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+        },
+        "inherits": {
+          "version": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+        },
+        "lodash": {
+          "version": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+        },
+        "lru-cache": {
+          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+        },
+        "minimatch": {
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "glob2base": {
+      "version": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+      "requires": {
+        "find-index": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+      }
+    },
+    "global-modules": {
+      "version": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "requires": {
+        "global-prefix": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+      },
+      "dependencies": {
+        "global-prefix": {
+          "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+          "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+          "requires": {
+            "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+            "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+          }
+        },
+        "is-windows": {
+          "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
+      }
+    },
+    "global-prefix": {
+      "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "requires": {
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+        "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+      }
+    },
+    "globals": {
+      "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+    },
+    "globby": {
+      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "requires": {
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "globjoin": {
+      "version": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
+    },
+    "globule": {
+      "version": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "glogg": {
+      "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "requires": {
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      }
+    },
+    "got": {
+      "version": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "requires": {
+        "create-error-class": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+        "is-redirect": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+        "is-retry-allowed": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+        "lowercase-keys": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+        "node-status-codes": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "read-all-stream": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "timed-out": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+        "unzip-response": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+        "url-parse-lax": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
+      }
+    },
+    "graceful-fs": {
+      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graceful-readlink": {
+      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "gray-matter": {
+      "version": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.0.2.tgz",
+      "integrity": "sha1-t7qT/XiQnYdevv/iiep+WcUp4Zs=",
+      "requires": {
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+        "strip-bom-string": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz"
+      },
+      "dependencies": {
+        "strip-bom-string": {
+          "version": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+          "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
+        }
+      }
+    },
+    "group-array": {
+      "version": "https://registry.npmjs.org/group-array/-/group-array-0.3.3.tgz",
+      "integrity": "sha1-u9nS9xjfS+M/D7kEMqrxtDYOSY8=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "split-string": "https://registry.npmjs.org/split-string/-/split-string-1.0.1.tgz",
+        "union-value": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "split-string": {
+          "version": "https://registry.npmjs.org/split-string/-/split-string-1.0.1.tgz",
+          "integrity": "sha1-vLqz9BUqzuOg1qskecDSh5w9s84=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+          }
+        }
+      }
+    },
+    "growly": {
+      "version": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
+    "gulp": {
+      "version": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "requires": {
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "deprecated": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+        "liftoff": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "orchestrator": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+        "pretty-hrtime": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+        "tildify": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+        "v8flags": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+          }
+        },
+        "glob-stream": {
+          "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+          "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+            "glob2base": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+            "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+          }
+        },
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "requires": {
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
+          }
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minimatch": {
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+          }
+        },
+        "ordered-read-streams": {
+          "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+          "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "semver": {
+          "version": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "strip-bom": {
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+          "requires": {
+            "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        },
+        "unique-stream": {
+          "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+          "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
+        },
+        "vinyl-fs": {
+          "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+          "requires": {
+            "defaults": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+            "glob-watcher": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+          }
+        }
+      }
+    },
+    "gulp-cached": {
+      "version": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
+      "integrity": "sha1-/nzU+H83YB5gc8/t7lwr2vi2rM4=",
+      "requires": {
+        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "gulp-changed": {
+      "version": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-3.1.0.tgz",
+      "integrity": "sha1-h80Vk6C7SlEp3C8im+zm2UiMJyo=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "gulp-debug": {
+      "version": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-3.1.0.tgz",
+      "integrity": "sha1-TakVaLVJFb6ANpbKqsEMiVssCnE=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "plur": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+        "stringify-object": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "tildify": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
+      }
+    },
+    "gulp-decompress": {
+      "version": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
+      "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
+      "requires": {
+        "archive-type": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
+        "decompress": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "gulp-eslint": {
+      "version": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-4.0.0.tgz",
+      "integrity": "sha1-FtnqTWlue3qdZe6xqlvEugoix/c=",
+      "requires": {
+        "eslint": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+      }
+    },
+    "gulp-extname": {
+      "version": "https://registry.npmjs.org/gulp-extname/-/gulp-extname-0.2.2.tgz",
+      "integrity": "sha1-NEmBFyxXUj2HgaPFvCyMussHrqs=",
+      "requires": {
+        "rewrite-ext": "https://registry.npmjs.org/rewrite-ext/-/rewrite-ext-0.2.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "gulp-filenames": {
+      "version": "https://registry.npmjs.org/gulp-filenames/-/gulp-filenames-4.0.1.tgz",
+      "integrity": "sha1-5Wmkd3uvdYs539kSDGYMDQmzLOE=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
+      },
+      "dependencies": {
+        "gulp-util": {
+          "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+            "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+              "requires": {
+                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                  "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+                },
+                "escape-string-regexp": {
+                  "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                },
+                "has-ansi": {
+                  "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                  "requires": {
+                    "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                  "requires": {
+                    "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                  "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+                }
+              }
+            },
+            "dateformat": {
+              "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
+              "requires": {
+                "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                "meow": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz"
+              },
+              "dependencies": {
+                "get-stdin": {
+                  "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+                },
+                "meow": {
+                  "version": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                  "integrity": "sha1-+Hd/0Ntn9z0d4b7uCMl8hmXvxu0=",
+                  "requires": {
+                    "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                    "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                    "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
+                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                  },
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
+                      "requires": {
+                        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+                        },
+                        "map-obj": {
+                          "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
+                      "requires": {
+                        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
+                        "repeating": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+                      },
+                      "dependencies": {
+                        "repeating": {
+                          "version": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                          "requires": {
+                            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+                          },
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
+                      "integrity": "sha1-r5YLgMr3GzgjY1Kvf+8QqO/O6uM="
+                    },
+                    "object-assign": {
+                      "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+              "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
+            },
+            "lodash.template": {
+              "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+              "requires": {
+                "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+                "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+                "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+              },
+              "dependencies": {
+                "lodash._escapestringchar": {
+                  "version": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+                  "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I="
+                },
+                "lodash.defaults": {
+                  "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
+                  "requires": {
+                    "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                    "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+                  },
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+                  "requires": {
+                    "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                    "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                    "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+                  },
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
+                      "requires": {
+                        "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                      },
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
+                      "requires": {
+                        "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+                      },
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+                  "requires": {
+                    "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                    "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                    "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                  },
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                    },
+                    "lodash._shimkeys": {
+                      "version": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+                      "requires": {
+                        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                        }
+                      }
+                    },
+                    "lodash.isobject": {
+                      "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                      "requires": {
+                        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+                  "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+                  "requires": {
+                    "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+                    "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
+                  }
+                },
+                "lodash.values": {
+                  "version": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+                  "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
+                  "requires": {
+                    "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+              "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
+            },
+            "multipipe": {
+              "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+              "requires": {
+                "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+              },
+              "dependencies": {
+                "duplexer2": {
+                  "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                  "requires": {
+                    "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                      "requires": {
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg="
+                        },
+                        "inherits": {
+                          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                        },
+                        "isarray": {
+                          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                        },
+                        "string_decoder": {
+                          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+                  "requires": {
+                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg="
+                    },
+                    "inherits": {
+                      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "isarray": {
+                      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    },
+                    "string_decoder": {
+                      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                  "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+                }
+              }
+            },
+            "vinyl": {
+              "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
+              "requires": {
+                "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+              },
+              "dependencies": {
+                "clone-stats": {
+                  "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+              "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
+              "requires": {
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg="
+                },
+                "inherits": {
+                  "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "process-nextick-args": {
+                  "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
+                  "integrity": "sha1-i00/xYZmi9W2Vz5zLt8rccHB2Ko="
+                },
+                "string_decoder": {
+                  "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "util-deprecate": {
+                  "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE="
+                }
+              }
+            },
+            "xtend": {
+              "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "integrity": "sha1-i8Nv+Hrtvnzp6vC8o2sjVKdDhA8="
+            }
+          }
+        }
+      }
+    },
+    "gulp-if": {
+      "version": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+      "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
+      "requires": {
+        "gulp-match": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+        "ternary-stream": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "gulp-imagemin": {
+      "version": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-3.3.0.tgz",
+      "integrity": "sha1-xVdkwmBZPoWVYJ5mpAEmkR7yImQ=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "imagemin": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
+        "imagemin-gifsicle": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz",
+        "imagemin-jpegtran": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-5.0.2.tgz",
+        "imagemin-optipng": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz",
+        "imagemin-svgo": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-5.2.2.tgz",
+        "plur": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+        "pretty-bytes": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+        "through2-concurrent": "https://registry.npmjs.org/through2-concurrent/-/through2-concurrent-1.1.1.tgz"
+      },
+      "dependencies": {
+        "pretty-bytes": {
+          "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+          "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+        }
+      }
+    },
+    "gulp-match": {
+      "version": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+      "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+      "requires": {
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+      }
+    },
+    "gulp-newer": {
+      "version": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.3.0.tgz",
+      "integrity": "sha1-1Q7Ky7gi7aSStXMkpshaB/2aVcE=",
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "kew": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "gulp-plumber": {
+      "version": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
+      "integrity": "sha1-8SF2wtBCL2AwbCQv/2oBo5T6ugk=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "gulp-postcss": {
+      "version": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.0.tgz",
+      "integrity": "sha1-z7YqGfqUf4vmfOnsronOuVnwz5M=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+        "postcss-load-config": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
+    },
+    "gulp-rename": {
+      "version": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
+    },
+    "gulp-rev": {
+      "version": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-7.1.2.tgz",
+      "integrity": "sha1-XhfMIp9rRcdCVviK0/LT6aMwWCk=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "modify-filename": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "rev-hash": "https://registry.npmjs.org/rev-hash/-/rev-hash-1.0.0.tgz",
+        "rev-path": "https://registry.npmjs.org/rev-path/-/rev-path-1.0.0.tgz",
+        "sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-file": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.3.0.tgz"
+      }
+    },
+    "gulp-sass": {
+      "version": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
+      "integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+        "node-sass": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
+    },
+    "gulp-size": {
+      "version": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.1.0.tgz",
+      "integrity": "sha1-HCtk8X+QcdWr2Z0VS3s0gfj7oSg=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "gzip-size": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pretty-bytes": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+        "stream-counter": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
+      "dependencies": {
+        "gzip-size": {
+          "version": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+          "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+          "requires": {
+            "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+          }
+        },
+        "pretty-bytes": {
+          "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+          "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+          "requires": {
+            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "gulp-sourcemaps": {
+      "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.0.tgz",
+      "integrity": "sha1-fMzomaijv8oVk6M0jQ+/Qd0/UeU=",
+      "requires": {
+        "@gulp-sourcemaps/identity-map": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
+        "@gulp-sourcemaps/map-sources": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "css": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+        "debug-fabulous": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.1.1.tgz",
+        "detect-newline": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+        "strip-bom-string": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
+      "dependencies": {
+        "strip-bom-string": {
+          "version": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+          "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
+        }
+      }
+    },
+    "gulp-strip-debug": {
+      "version": "https://registry.npmjs.org/gulp-strip-debug/-/gulp-strip-debug-1.1.0.tgz",
+      "integrity": "sha1-XVawCEUu32gj2t7LPmJU0G87XT0=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "strip-debug": "https://registry.npmjs.org/strip-debug/-/strip-debug-1.1.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "gulp-svgmin": {
+      "version": "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-1.2.4.tgz",
+      "integrity": "sha1-pKqeJhXPEQXvVVrqhuhilswg4nM=",
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
+      }
+    },
+    "gulp-svgstore": {
+      "version": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.1.0.tgz",
+      "integrity": "sha1-BLIDrA4T+O1tv8lA0lllxOJFZnY=",
+      "requires": {
+        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+      }
+    },
+    "gulp-tap": {
+      "version": "https://registry.npmjs.org/gulp-tap/-/gulp-tap-1.0.1.tgz",
+      "integrity": "sha1-5nESThJZtM6iGe0cqXt/WFwzRpA=",
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "gulp-uglify": {
+      "version": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
+      "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
+      "requires": {
+        "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+        "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "make-error-cause": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "uglify-js": {
+          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+          "integrity": "sha1-qX24yLprnbpOL4jYaqlUj6YyADQ=",
+          "requires": {
+            "commander": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "requires": {
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+        "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+        "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+        "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+        "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+        "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+        "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
+        }
+      }
+    },
+    "gulplog": {
+      "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "requires": {
+        "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+      }
+    },
+    "gzip-size": {
+      "version": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+      "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
+      "requires": {
+        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz"
+      }
+    },
+    "handlebars": {
+      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz"
+      }
+    },
+    "handlebars-helper-create-frame": {
+      "version": "https://registry.npmjs.org/handlebars-helper-create-frame/-/handlebars-helper-create-frame-0.1.0.tgz",
+      "integrity": "sha1-iqUdEK62QI/MZgXUDXc1YohIegM=",
+      "requires": {
+        "create-frame": "https://registry.npmjs.org/create-frame/-/create-frame-1.0.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+      }
+    },
+    "handlebars-helpers": {
+      "version": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.8.4.tgz",
+      "integrity": "sha1-+YgLeujYkOYxoxRvAZBQAFxU7RI=",
+      "requires": {
+        "arr-filter": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "array-sort": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.3.tgz",
+        "create-frame": "https://registry.npmjs.org/create-frame/-/create-frame-1.0.0.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "for-in": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+        "get-object": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+        "helper-date": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
+        "helper-markdown": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.2.tgz",
+        "helper-md": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz",
+        "html-tag": "https://registry.npmjs.org/html-tag/-/html-tag-1.0.0.tgz",
+        "index-of": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
+        "is-even": "https://registry.npmjs.org/is-even/-/is-even-0.1.2.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+        "is-odd": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "logging-helpers": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
+        "make-iterator": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.3.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+        "relative": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+        "striptags": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+        "to-gfm-code-block": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+        },
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "make-iterator": {
+          "version": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.3.1.tgz",
+          "integrity": "sha1-4calMrVGon8TlIoG+CUJsz25gRI=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          }
+        }
+      }
+    },
+    "handlebars-utils": {
+      "version": "https://registry.npmjs.org/handlebars-utils/-/handlebars-utils-1.0.2.tgz",
+      "integrity": "sha1-FGuaKDwg0grANbrbpvMcLwVgSwM=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+        "typeof-article": "https://registry.npmjs.org/typeof-article/-/typeof-article-0.1.1.tgz"
+      }
+    },
+    "har-schema": {
+      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+    },
+    "har-validator": {
+      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "requires": {
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+      }
+    },
+    "has": {
+      "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "requires": {
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+      }
+    },
+    "has-ansi": {
+      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+      }
+    },
+    "has-binary": {
+      "version": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+      "requires": {
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
+    "has-cors": {
+      "version": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
+    "has-flag": {
+      "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "has-glob": {
+      "version": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
+      "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
+      "requires": {
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz"
+      }
+    },
+    "has-gulplog": {
+      "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "requires": {
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      }
+    },
+    "has-own-deep": {
+      "version": "https://registry.npmjs.org/has-own-deep/-/has-own-deep-0.1.4.tgz",
+      "integrity": "sha1-kesM2ieAgxWPgEKigxZDTpr+eHY="
+    },
+    "has-unicode": {
+      "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "has-value": {
+      "version": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "requires": {
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "has-values": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "has-values": {
+      "version": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+    },
+    "hash-base": {
+      "version": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "hash.js": {
+      "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
+    },
+    "hawk": {
+      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      }
+    },
+    "helper-cache": {
+      "version": "https://registry.npmjs.org/helper-cache/-/helper-cache-0.7.2.tgz",
+      "integrity": "sha1-AkVixLS4sqsqtTHQC+FuxJZRi5A=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+        "lodash.bind": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
+      }
+    },
+    "helper-date": {
+      "version": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
+      "integrity": "sha1-2HDKu6BB0ynMhW2yC7jElnTj7yg=",
+      "requires": {
+        "date.js": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "moment": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "helper-markdown": {
+      "version": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.2.tgz",
+      "integrity": "sha1-ONt/dxhJ4wrpXJL8AhuutT8uMEA=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "remarkable": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "helper-md": {
+      "version": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz",
+      "integrity": "sha1-wfWdflW7riM2L9ig6XFgeuxp1B8=",
+      "requires": {
+        "ent": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "remarkable": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz"
+      }
+    },
+    "highlight.js": {
+      "version": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+    },
+    "hmac-drbg": {
+      "version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+        "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+      }
+    },
+    "hoek": {
+      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "home-or-tmp": {
+      "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "requires": {
+        "parse-passwd": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
+      }
+    },
+    "hosted-git-info": {
+      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
+    },
+    "html-comment-regex": {
+      "version": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
+    },
+    "html-encoding-sniffer": {
+      "version": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+      "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+      "requires": {
+        "whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz"
+      }
+    },
+    "html-tag": {
+      "version": "https://registry.npmjs.org/html-tag/-/html-tag-1.0.0.tgz",
+      "integrity": "sha1-leVhKuyCvqko7URZX4VBRen34LU=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "void-elements": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
+      }
+    },
+    "html-tags": {
+      "version": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
+    },
+    "htmlescape": {
+      "version": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
+    },
+    "htmlparser2": {
+      "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "requires": {
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+        "domhandler": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "http-errors": {
+      "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+      "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      }
+    },
+    "http-proxy": {
+      "version": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+      "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
+      "requires": {
+        "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+        "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+      }
+    },
+    "http-signature": {
+      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+      }
+    },
+    "https-browserify": {
+      "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "optional": true,
+      "requires": {
+        "agent-base": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+      }
+    },
+    "iconv-lite": {
+      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
+    },
+    "ieee754": {
+      "version": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "ignore": {
+      "version": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0="
+    },
+    "imagemin": {
+      "version": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
+      "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
+      "requires": {
+        "file-type": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+        "globby": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+        "make-dir": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+        "p-pipe": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "globby": {
+          "version": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
+        },
+        "replace-ext": {
+          "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+        }
+      }
+    },
+    "imagemin-gifsicle": {
+      "version": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz",
+      "integrity": "sha1-N4FSTEV2Eu8EkWrzQkGitCv8tAo=",
+      "optional": true,
+      "requires": {
+        "exec-buffer": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+        "gifsicle": "https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.4.tgz",
+        "is-gif": "https://registry.npmjs.org/is-gif/-/is-gif-1.0.0.tgz"
+      }
+    },
+    "imagemin-jpegtran": {
+      "version": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-5.0.2.tgz",
+      "integrity": "sha1-5ogiY7j3kW/duABkDPddLpcNKtY=",
+      "optional": true,
+      "requires": {
+        "exec-buffer": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+        "is-jpg": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.0.tgz",
+        "jpegtran-bin": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz"
+      }
+    },
+    "imagemin-optipng": {
+      "version": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz",
+      "integrity": "sha1-0i2kEsCfX/AKQzmWC5ioix2+hpU=",
+      "optional": true,
+      "requires": {
+        "exec-buffer": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+        "is-png": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
+        "optipng-bin": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.4.tgz"
+      }
+    },
+    "imagemin-svgo": {
+      "version": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-5.2.2.tgz",
+      "integrity": "sha1-UBaZ9XiXMKV5IrhzbqFcU/e1WDg=",
+      "optional": true,
+      "requires": {
+        "is-svg": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
+      }
+    },
+    "immutable": {
+      "version": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
+    },
+    "imurmurhash": {
+      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "in-publish": {
+      "version": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+    },
+    "include-media": {
+      "version": "https://registry.npmjs.org/include-media/-/include-media-1.4.9.tgz",
+      "integrity": "sha1-0AILe+PrLVSGiiCUNZXOOA4LxDs="
+    },
+    "indent-string": {
+      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "requires": {
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+      }
+    },
+    "index-of": {
+      "version": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
+      "integrity": "sha1-OMHiNn6lXf+tO261kuwcwwkNfWU="
+    },
+    "indexes-of": {
+      "version": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+    },
+    "indexof": {
+      "version": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflection": {
+      "version": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+    },
+    "inflight": {
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
+    },
+    "info-symbol": {
+      "version": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
+      "integrity": "sha1-J4QdcoZ920JCzWEtecEGM4gcang="
+    },
+    "inherits": {
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "inline-source-map": {
+      "version": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "inquirer": {
+      "version": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+      "integrity": "sha1-Bs6w9UD0XKVIwX1oQJWYeCZfoXU=",
+      "requires": {
+        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+        "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
+        "figures": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+        "run-async": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+        "rx-lite-aggregates": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
+        },
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "requires": {
+            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+          }
+        },
+        "chalk": {
+          "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+          }
+        },
+        "cli-cursor": {
+          "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz"
+          }
+        },
+        "cli-width": {
+          "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+        },
+        "figures": {
+          "version": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "requires": {
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "mute-stream": {
+          "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "onetime": {
+          "version": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
+          }
+        },
+        "restore-cursor": {
+          "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+          }
+        },
+        "run-async": {
+          "version": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "requires": {
+            "is-promise": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
+          }
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          }
+        },
+        "strip-ansi": {
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+          }
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+          }
+        }
+      }
+    },
+    "inquirer2": {
+      "version": "https://registry.npmjs.org/inquirer2/-/inquirer2-0.1.1.tgz",
+      "integrity": "sha1-vFQkqBQ1fEHmXi6Vf+U2ruqb8fY=",
+      "requires": {
+        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "arr-pluck": "https://registry.npmjs.org/arr-pluck/-/arr-pluck-0.1.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+        "lodash.where": "https://registry.npmjs.org/lodash.where/-/lodash.where-3.1.0.tgz",
+        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+        "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+        "strip-color": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "insert-module-globals": {
+      "version": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+      "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
+      "requires": {
+        "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "lexical-scope": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "interpret": {
+      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+    },
+    "invariant": {
+      "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+      }
+    },
+    "invert-kv": {
+      "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "ip-regex": {
+      "version": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
+      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
+      "optional": true
+    },
+    "irregular-plurals": {
+      "version": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
+      "integrity": "sha1-evBpMb33S+M9z1haE+BvzMFsrs8="
+    },
+    "is-absolute": {
+      "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "requires": {
+        "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
+      }
+    },
+    "is-absolute-url": {
+      "version": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+    },
+    "is-accessor-descriptor": {
+      "version": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "is-answer": {
+      "version": "https://registry.npmjs.org/is-answer/-/is-answer-0.1.1.tgz",
+      "integrity": "sha1-zBwvGG+FzyZQIgveNZ2GIYfUnLY=",
+      "requires": {
+        "has-values": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz"
+      }
+    },
+    "is-arguments": {
+      "version": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.2.tgz",
+      "integrity": "sha1-B+MK15UxhEF5tkLS2DmUNRgshyc="
+    },
+    "is-arrayish": {
+      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-binary-buffer": {
+      "version": "https://registry.npmjs.org/is-binary-buffer/-/is-binary-buffer-1.0.0.tgz",
+      "integrity": "sha1-vGAxKQtly/eZudlQK1D9U3VSQAc=",
+      "requires": {
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+      }
+    },
+    "is-binary-path": {
+      "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz"
+      }
+    },
+    "is-buffer": {
+      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+    },
+    "is-builtin-module": {
+      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      }
+    },
+    "is-bzip2": {
+      "version": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
+      "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w="
+    },
+    "is-ci": {
+      "version": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "requires": {
+        "ci-info": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-descriptor": {
+      "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "requires": {
+        "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+        "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz"
+      }
+    },
+    "is-directory": {
+      "version": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+    },
+    "is-dotfile": {
+      "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      }
+    },
+    "is-even": {
+      "version": "https://registry.npmjs.org/is-even/-/is-even-0.1.2.tgz",
+      "integrity": "sha1-4EMqc3ny0gtuu8LLEeab6q8xzWM=",
+      "requires": {
+        "is-odd": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz"
+      }
+    },
+    "is-extendable": {
+      "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-finite": {
+      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      }
+    },
+    "is-generator": {
+      "version": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM="
+    },
+    "is-gif": {
+      "version": "https://registry.npmjs.org/is-gif/-/is-gif-1.0.0.tgz",
+      "integrity": "sha1-ptKumIkwB7/6l6HYwB1jIFgyCX4=",
+      "optional": true
+    },
+    "is-glob": {
+      "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "requires": {
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+      }
+    },
+    "is-gzip": {
+      "version": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+    },
+    "is-jpg": {
+      "version": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.0.tgz",
+      "integrity": "sha1-KVnBfnNDDbOCZNp1uQ3VTy2G2hw=",
+      "optional": true
+    },
+    "is-natural-number": {
+      "version": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
+      "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec="
+    },
+    "is-npm": {
+      "version": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+    },
+    "is-number": {
+      "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "is-number-like": {
+      "version": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha1-LhKWILUIkQQuROm7uzBZPnXPu+M=",
+      "requires": {
+        "lodash.isfinite": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz"
+      }
+    },
+    "is-obj": {
+      "version": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-odd": {
+      "version": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
+      "integrity": "sha1-vFc7XONx7yqtbm9JeZtyvvE5eKc=",
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "is-path-cwd": {
+      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+    },
+    "is-path-in-cwd": {
+      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "requires": {
+        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+      }
+    },
+    "is-path-inside": {
+      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "requires": {
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+      }
+    },
+    "is-plain-obj": {
+      "version": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-plain-object": {
+      "version": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+      }
+    },
+    "is-png": {
+      "version": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
+      "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
+      "optional": true
+    },
+    "is-posix-bracket": {
+      "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-promise": {
+      "version": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-redirect": {
+      "version": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
+    "is-regexp": {
+      "version": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+    },
+    "is-registered": {
+      "version": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+      "integrity": "sha1-HTRpd0GdZl4qxshAE1NWheb3b38=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "is-relative": {
+      "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "requires": {
+        "is-unc-path": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz"
+      }
+    },
+    "is-resolvable": {
+      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "requires": {
+        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+      }
+    },
+    "is-retry-allowed": {
+      "version": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
+    "is-stream": {
+      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-supported-regexp-flag": {
+      "version": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
+      "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g="
+    },
+    "is-svg": {
+      "version": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "requires": {
+        "html-comment-regex": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+      }
+    },
+    "is-tar": {
+      "version": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
+      "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0="
+    },
+    "is-typedarray": {
+      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unc-path": {
+      "version": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "requires": {
+        "unc-path-regex": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
+      }
+    },
+    "is-url": {
+      "version": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
+    },
+    "is-utf8": {
+      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-valid-app": {
+      "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
+      "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+        "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.3.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+      }
+    },
+    "is-valid-glob": {
+      "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+    },
+    "is-valid-instance": {
+      "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.3.0.tgz",
+      "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+      }
+    },
+    "is-whitespace": {
+      "version": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38="
+    },
+    "is-windows": {
+      "version": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+    },
+    "is-zip": {
+      "version": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
+      "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU="
+    },
+    "isarray": {
+      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isstream": {
+      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "istanbul-api": {
+      "version": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
+      "integrity": "sha1-/MC0YeKzvaceMFFVE4I4doJX2d4=",
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+        "fileset": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+        "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+        "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+        "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      },
+      "dependencies": {
+        "async": {
+          "version": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "requires": {
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
+        }
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo="
+    },
+    "istanbul-lib-hook": {
+      "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+      "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+      "requires": {
+        "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+      "integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
+      "requires": {
+        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
+      "requires": {
+        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+      "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
+      "requires": {
+        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
+      }
+    },
+    "jest-changed-files": {
+      "version": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
+      "integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
+    },
+    "jest-cli": {
+      "version": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+      "integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+      "requires": {
+        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+        "callsites": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "is-ci": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+        "istanbul-api": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
+        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+        "jest-changed-files": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
+        "jest-config": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+        "jest-docblock": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+        "jest-environment-jsdom": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
+        "jest-haste-map": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
+        "jest-jasmine2": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
+        "jest-message-util": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+        "jest-regex-util": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+        "jest-resolve-dependencies": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
+        "jest-runtime": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
+        "jest-snapshot": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
+        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "node-notifier": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "string-length": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+        "throat": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+        "worker-farm": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+        },
+        "cliui": {
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+          }
+        },
+        "yargs": {
+          "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+          }
+        },
+        "yargs-parser": {
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          }
+        }
+      }
+    },
+    "jest-config": {
+      "version": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+      "integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "jest-environment-jsdom": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
+        "jest-environment-node": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
+        "jest-jasmine2": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
+        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+        "jest-regex-util": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+        "jest-resolve": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
+        "jest-validate": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
+        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+      "integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "diff": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
+        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz"
+      }
+    },
+    "jest-docblock": {
+      "version": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+      "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+    },
+    "jest-environment-jsdom": {
+      "version": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
+      "integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+      "requires": {
+        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+        "jsdom": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz"
+      }
+    },
+    "jest-environment-node": {
+      "version": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
+      "integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+      "requires": {
+        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz"
+      }
+    },
+    "jest-haste-map": {
+      "version": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
+      "integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
+      "requires": {
+        "fb-watchman": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jest-docblock": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "sane": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
+        "worker-farm": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
+      "integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jest-diff": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+        "jest-matchers": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
+        "jest-message-util": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+        "jest-snapshot": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "p-map": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+      "integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz"
+      }
+    },
+    "jest-matchers": {
+      "version": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
+      "integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+      "requires": {
+        "jest-diff": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+        "jest-message-util": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+        "jest-regex-util": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz"
+      }
+    },
+    "jest-message-util": {
+      "version": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+      "integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+      }
+    },
+    "jest-mock": {
+      "version": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+      "integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
+    },
+    "jest-regex-util": {
+      "version": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+      "integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
+    },
+    "jest-resolve": {
+      "version": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
+      "integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+      "requires": {
+        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
+      "integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+      "requires": {
+        "jest-regex-util": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz"
+      }
+    },
+    "jest-runtime": {
+      "version": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
+      "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+        "babel-jest": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
+        "babel-plugin-istanbul": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jest-config": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+        "jest-haste-map": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
+        "jest-regex-util": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+        "jest-resolve": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
+        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+          }
+        },
+        "strip-bom": {
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        },
+        "yargs": {
+          "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+          }
+        },
+        "yargs-parser": {
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          }
+        }
+      }
+    },
+    "jest-snapshot": {
+      "version": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
+      "integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "jest-diff": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz"
+      }
+    },
+    "jest-util": {
+      "version": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+      "integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jest-message-util": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+        "jest-validate": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
+        "leven": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      }
+    },
+    "jest-validate": {
+      "version": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
+      "integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+        "leven": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz"
+      }
+    },
+    "jpegtran-bin": {
+      "version": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz",
+      "integrity": "sha1-9g7PSumZwL2tLp+83ytvCYHnops=",
+      "optional": true,
+      "requires": {
+        "bin-build": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
+        "bin-wrapper": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+        "logalot": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz"
+      }
+    },
+    "js-base64": {
+      "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+    },
+    "js-tokens": {
+      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "js-yaml": {
+      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha1-CHdc69/dNZIJ8NKs04PI+GppBKA=",
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
+      }
+    },
+    "jsbn": {
+      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jschardet": {
+      "version": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha1-xRn2KfhrOlvtuliojTETCe7Al/k="
+    },
+    "jsdom": {
+      "version": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+      "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+      "requires": {
+        "abab": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+        "acorn-globals": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+        "array-equal": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+        "content-type-parser": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+        "cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+        "cssstyle": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+        "html-encoding-sniffer": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+        "nwmatcher": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
+        "parse5": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "symbol-tree": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
+        "whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+        "whatwg-url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+        "xml-name-validator": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+      }
+    },
+    "jsesc": {
+      "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
+    "json-schema": {
+      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify": {
+      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    },
+    "json5": {
+      "version": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "jsonfile": {
+      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      }
+    },
+    "jsonfilter": {
+      "version": "https://registry.npmjs.org/jsonfilter/-/jsonfilter-1.1.2.tgz",
+      "integrity": "sha1-Ie987cdRk4E8dZMulqmL4gW6WhE=",
+      "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "jsonparse": {
+          "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
+        },
+        "JSONStream": {
+          "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+          "requires": {
+            "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          }
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        }
+      }
+    },
+    "jsonify": {
+      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonparse": {
+      "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "JSONStream": {
+      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
+    "jsprim": {
+      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+        "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "kew": {
+      "version": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
+    },
+    "kind-of": {
+      "version": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+      "integrity": "sha1-9Xvskz2aIgn/qWxcCDQ2B7cDX9o="
+    },
+    "klaw": {
+      "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      }
+    },
+    "known-css-properties": {
+      "version": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
+      "integrity": "sha1-iZyUvjaOVbQtfbjVvn1zpKSkFFQ="
+    },
+    "labeled-stream-splicer": {
+      "version": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "stream-splicer": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
+    "latest-version": {
+      "version": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "requires": {
+        "package-json": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz"
+      }
+    },
+    "layouts": {
+      "version": "https://registry.npmjs.org/layouts/-/layouts-0.12.1.tgz",
+      "integrity": "sha1-a5mz8apT5eeMkOx11PSRpuD1cEM=",
+      "requires": {
+        "delimiter-regex": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-1.3.1.tgz",
+        "falsey": "https://registry.npmjs.org/falsey/-/falsey-0.3.0.tgz",
+        "get-view": "https://registry.npmjs.org/get-view/-/get-view-0.1.3.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+      },
+      "dependencies": {
+        "delimiter-regex": {
+          "version": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-1.3.1.tgz",
+          "integrity": "sha1-Y4XK4UAE28DBzY3//+uGPVGZnv8=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz"
+          }
+        },
+        "extend-shallow": {
+          "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        }
+      }
+    },
+    "lazy-cache": {
+      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "requires": {
+        "set-getter": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz"
+      }
+    },
+    "lazy-req": {
+      "version": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
+    },
+    "lazystream": {
+      "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "lcid": {
+      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+      }
+    },
+    "ldjson-stream": {
+      "version": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
+      "integrity": "sha1-kb7O2lrE7SsX5kn7d356v6AYnCs=",
+      "requires": {
+        "split2": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        }
+      }
+    },
+    "leven": {
+      "version": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+    },
+    "levn": {
+      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+      }
+    },
+    "lexical-scope": {
+      "version": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
+      "requires": {
+        "astw": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz"
+      }
+    },
+    "liftoff": {
+      "version": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+      "requires": {
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+        "fined": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+        "flagged-respawn": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+        "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+        "lodash.isstring": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+        "lodash.mapvalues": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      }
+    },
+    "limiter": {
+      "version": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
+      "integrity": "sha1-Ip2AVYkcixGvng7lIA6OCbs9y+s="
+    },
+    "load-helpers": {
+      "version": "https://registry.npmjs.org/load-helpers/-/load-helpers-0.3.1.tgz",
+      "integrity": "sha1-mai6BzYpAYJ8jmLJWwsLH+mDBUk=",
+      "requires": {
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "matched": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "expand-tilde": {
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "has-glob": {
+          "version": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+          "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        },
+        "matched": {
+          "version": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+          "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
+          "requires": {
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "async-array-reduce": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+            "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+          }
+        },
+        "resolve-dir": {
+          "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "requires": {
+            "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+          }
+        }
+      }
+    },
+    "load-json-file": {
+      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      }
+    },
+    "load-pkg": {
+      "version": "https://registry.npmjs.org/load-pkg/-/load-pkg-3.0.1.tgz",
+      "integrity": "sha1-kjCzfsBOVpADBgvFiVHj7VCNWU8=",
+      "requires": {
+        "find-pkg": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz"
+      }
+    },
+    "load-templates": {
+      "version": "https://registry.npmjs.org/load-templates/-/load-templates-1.0.2.tgz",
+      "integrity": "sha1-CfOOlcjvS/t4W9f8qOv9MrIwvIc=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "file-contents": "https://registry.npmjs.org/file-contents/-/file-contents-1.0.1.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "matched": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "clone": {
+          "version": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+        },
+        "clone-stats": {
+          "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+        },
+        "expand-tilde": {
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "has-glob": {
+          "version": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+          "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "requires": {
+                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "matched": {
+          "version": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+          "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
+          "requires": {
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "async-array-reduce": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+            "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+          }
+        },
+        "replace-ext": {
+          "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+        },
+        "resolve-dir": {
+          "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "requires": {
+            "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+          }
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+            "clone-buffer": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "cloneable-readable": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "localtunnel": {
+      "version": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
+      "integrity": "sha1-3MWSL9hWUQN9S94k/ZMkjQsk6wU=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "openurl": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "cliui": {
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+          }
+        },
+        "window-size": {
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+        },
+        "yargs": {
+          "version": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
+          "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+          }
+        }
+      }
+    },
+    "locate-path": {
+      "version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
+      }
+    },
+    "lodash": {
+      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._arrayfilter": {
+      "version": "https://registry.npmjs.org/lodash._arrayfilter/-/lodash._arrayfilter-3.0.0.tgz",
+      "integrity": "sha1-LevhHuxp5dzG9LhhNxKKSPFSQjc="
+    },
+    "lodash._basecallback": {
+      "version": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+      "requires": {
+        "lodash._baseisequal": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+        "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+        "lodash.pairs": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._baseeach": {
+      "version": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+      "requires": {
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      }
+    },
+    "lodash._basefilter": {
+      "version": "https://registry.npmjs.org/lodash._basefilter/-/lodash._basefilter-3.0.0.tgz",
+      "integrity": "sha1-S3ZAPfDihtA9Xg9yle00QeEB0SE=",
+      "requires": {
+        "lodash._baseeach": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz"
+      }
+    },
+    "lodash._baseisequal": {
+      "version": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "requires": {
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+        "lodash.istypedarray": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      }
+    },
+    "lodash._baseismatch": {
+      "version": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
+      "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
+      "requires": {
+        "lodash._baseisequal": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz"
+      }
+    },
+    "lodash._basematches": {
+      "version": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
+      "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
+      "requires": {
+        "lodash._baseismatch": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
+        "lodash.pairs": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz"
+      }
+    },
+    "lodash._basetostring": {
+      "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+    },
+    "lodash._basevalues": {
+      "version": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._bindcallback": {
+      "version": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._createwrapper": {
+      "version": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.2.0.tgz",
+      "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0=",
+      "requires": {
+        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+      }
+    },
+    "lodash._getnative": {
+      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash._reescape": {
+      "version": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+    },
+    "lodash._reevaluate": {
+      "version": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+    },
+    "lodash._reinterpolate": {
+      "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash._replaceholders": {
+      "version": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
+      "integrity": "sha1-iru3EmxDH37XRPe6rznwi8m9nVg="
+    },
+    "lodash._root": {
+      "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+    },
+    "lodash.assign": {
+      "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.assignin": {
+      "version": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+    },
+    "lodash.bind": {
+      "version": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
+      "integrity": "sha1-+V9IY419i7tYVPkIJmUnmZ+/pLs=",
+      "requires": {
+        "lodash._createwrapper": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.2.0.tgz",
+        "lodash._replaceholders": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
+        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+      }
+    },
+    "lodash.clonedeep": {
+      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.cond": {
+      "version": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+    },
+    "lodash.defaults": {
+      "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.escape": {
+      "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "requires": {
+        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+      }
+    },
+    "lodash.filter": {
+      "version": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+    },
+    "lodash.findkey": {
+      "version": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
+      "integrity": "sha1-gwWOkDtRy7dZ0JzPVG3qPqOcRxg="
+    },
+    "lodash.flatten": {
+      "version": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.foreach": {
+      "version": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.includes": {
+      "version": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.initial": {
+      "version": "https://registry.npmjs.org/lodash.initial/-/lodash.initial-4.1.1.tgz",
+      "integrity": "sha1-5T9kiRJl3cQE6YbSwo93vtlDWRo="
+    },
+    "lodash.isarguments": {
+      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isempty": {
+      "version": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.isequal": {
+      "version": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isfinite": {
+      "version": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
+    },
+    "lodash.isplainobject": {
+      "version": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.istypedarray": {
+      "version": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+    },
+    "lodash.keys": {
+      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      }
+    },
+    "lodash.last": {
+      "version": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
+    },
+    "lodash.map": {
+      "version": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+    },
+    "lodash.mapvalues": {
+      "version": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
+    },
+    "lodash.memoize": {
+      "version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
+    },
+    "lodash.merge": {
+      "version": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
+    "lodash.mergewith": {
+      "version": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
+    },
+    "lodash.pairs": {
+      "version": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+      "requires": {
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      }
+    },
+    "lodash.partition": {
+      "version": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q="
+    },
+    "lodash.pick": {
+      "version": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.reduce": {
+      "version": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
+    "lodash.reject": {
+      "version": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+    },
+    "lodash.restparam": {
+      "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.some": {
+      "version": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+    },
+    "lodash.template": {
+      "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "requires": {
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+        "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "requires": {
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+      }
+    },
+    "lodash.trim": {
+      "version": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+      "integrity": "sha1-NkJefukL5KpeJ7zruFt9EepHqlc="
+    },
+    "lodash.uniq": {
+      "version": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.where": {
+      "version": "https://registry.npmjs.org/lodash.where/-/lodash.where-3.1.0.tgz",
+      "integrity": "sha1-LnhLnJM2jV11qu4zLOF2Ai8rlVM=",
+      "requires": {
+        "lodash._arrayfilter": "https://registry.npmjs.org/lodash._arrayfilter/-/lodash._arrayfilter-3.0.0.tgz",
+        "lodash._basecallback": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+        "lodash._basefilter": "https://registry.npmjs.org/lodash._basefilter/-/lodash._basefilter-3.0.0.tgz",
+        "lodash._basematches": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      }
+    },
+    "log-ok": {
+      "version": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+      "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
+      "requires": {
+        "ansi-green": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+        "success-symbol": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+      }
+    },
+    "log-symbols": {
+      "version": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      }
+    },
+    "log-utils": {
+      "version": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+      "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
+      "requires": {
+        "ansi-colors": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
+        "error-symbol": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
+        "info-symbol": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
+        "log-ok": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+        "success-symbol": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+        "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+        "warning-symbol": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz"
+      }
+    },
+    "logalot": {
+      "version": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+      "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
+      "optional": true,
+      "requires": {
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "squeak": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz"
+      }
+    },
+    "logging-helpers": {
+      "version": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
+      "integrity": "sha1-AObVMWwjdn7BLhIA5PEsXgM+frA=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      }
+    },
+    "longest": {
+      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+    },
+    "loose-envify": {
+      "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+      }
+    },
+    "loud-rejection": {
+      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "requires": {
+        "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+      }
+    },
+    "lower-case": {
+      "version": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lowercase-keys": {
+      "version": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+    },
+    "lpad-align": {
+      "version": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
+      "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
+      "optional": true,
+      "requires": {
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "optional": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "requires": {
+        "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+        "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+      }
+    },
+    "lru-queue": {
+      "version": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz"
+      }
+    },
+    "macaddress": {
+      "version": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
+    },
+    "make-dir": {
+      "version": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "requires": {
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+      }
+    },
+    "make-error": {
+      "version": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
+      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y="
+    },
+    "make-error-cause": {
+      "version": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "requires": {
+        "make-error": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz"
+      }
+    },
+    "make-iterator": {
+      "version": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+      "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "makeerror": {
+      "version": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "requires": {
+        "tmpl": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
+      }
+    },
+    "map-cache": {
+      "version": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-config": {
+      "version": "https://registry.npmjs.org/map-config/-/map-config-0.5.0.tgz",
+      "integrity": "sha1-FwJgfiZ696NwyKnQxiumUk/rb+U=",
+      "requires": {
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+      }
+    },
+    "map-obj": {
+      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "map-schema": {
+      "version": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
+      "integrity": "sha1-wZVRg0/DwHoEWXt6WvtEpHWvlbQ=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "collection-visit": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+        "pad-right": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+        "sort-object-arrays": "https://registry.npmjs.org/sort-object-arrays/-/sort-object-arrays-0.1.1.tgz",
+        "union-value": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "map-visit": {
+      "version": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
+      "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
+      "requires": {
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz"
+      }
+    },
+    "match-file": {
+      "version": "https://registry.npmjs.org/match-file/-/match-file-0.2.2.tgz",
+      "integrity": "sha1-Jua88bOQpmH2Em+visUB4z7M+uk=",
+      "requires": {
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+      }
+    },
+    "matched": {
+      "version": "https://registry.npmjs.org/matched/-/matched-1.0.2.tgz",
+      "integrity": "sha1-HZXXfdXxtQdanpSs3lRi/9hfMXo=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "async-array-reduce": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
+        "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "is-valid-glob": {
+          "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+          "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
+        }
+      }
+    },
+    "math-expression-evaluator": {
+      "version": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+    },
+    "mathml-tag-names": {
+      "version": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz",
+      "integrity": "sha1-jUEmgWi/htEQK5gQnijlMeejRXg="
+    },
+    "memoizee": {
+      "version": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.5.tgz",
+      "integrity": "sha1-G8PqHkvgVt1HXVIZede+PV5bIcg=",
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+        "is-promise": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+        "lru-queue": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+        "next-tick": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+        "timers-ext": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz"
+      },
+      "dependencies": {
+        "next-tick": {
+          "version": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+        }
+      }
+    },
+    "meow": {
+      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "requires": {
+        "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+        "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+      }
+    },
+    "merge": {
+      "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+    },
+    "merge-deep": {
+      "version": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.0.tgz",
+      "integrity": "sha1-zJEp3tedymWpUUSvPpjpTSrXoxc=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "clone-deep": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "merge-value": {
+      "version": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
+      "integrity": "sha1-0o+NQcCzdCbgMtEFmg0DQzAt5QI=",
+      "requires": {
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.0.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.0.tgz",
+          "integrity": "sha1-+/ureeuc6h4eisjbw6iQe1S6pIY=",
+          "requires": {
+            "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "split-string": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+            }
+          }
+        }
+      }
+    },
+    "micromatch": {
+      "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+        "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+        "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+        "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+        "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "miller-rabin": {
+      "version": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+      }
+    },
+    "mime": {
+      "version": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+      "integrity": "sha1-EbX9rynCUJJVF2uArVIClPXekrc="
+    },
+    "mime-db": {
+      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+    },
+    "mime-types": {
+      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "requires": {
+        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+      }
+    },
+    "mimic-fn": {
+      "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+    },
+    "minimalistic-assert": {
+      "version": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "minimatch": {
+      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "requires": {
+        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+      }
+    },
+    "minimist": {
+      "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-deep": {
+      "version": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+      "integrity": "sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=",
+      "requires": {
+        "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      }
+    },
+    "mixin-object": {
+      "version": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "requires": {
+        "for-in": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "modify-filename": {
+      "version": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
+      "integrity": "sha1-mi3sg4Bvuy2XXyK+7IWcoms5OqE="
+    },
+    "module-deps": {
+      "version": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+      "requires": {
+        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+        "cached-path-relative": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "detective": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+        "stream-combiner2": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+        "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "mold-source-map": {
+      "version": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
+      "integrity": "sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=",
+      "requires": {
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
+      },
+      "dependencies": {
+        "through": {
+          "version": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0="
+        }
+      }
+    },
+    "moment": {
+      "version": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "ms": {
+      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multimatch": {
+      "version": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "requires": {
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+      }
+    },
+    "multipipe": {
+      "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "requires": {
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+          }
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "mute-stream": {
+      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+    },
+    "nan": {
+      "version": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+    },
+    "nanomatch": {
+      "version": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.0.tgz",
+      "integrity": "sha1-dv2z1K52F+N3GeekBHuECFfAyxw=",
+      "requires": {
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "fragment-cache": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+        "is-odd": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+        "regex-not": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+        "snapdragon": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+        "to-regex": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "array-unique": {
+          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "define-property": {
+          "version": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz"
+          }
+        },
+        "is-descriptor": {
+          "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+          "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
+          "requires": {
+            "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "kind-of": "5.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+              "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw=="
+            }
+          }
+        },
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "is-odd": {
+          "version": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
+          "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "nanoseconds": {
+      "version": "https://registry.npmjs.org/nanoseconds/-/nanoseconds-0.1.0.tgz",
+      "integrity": "sha1-aew5/NAOd6s6ct4KQzQoJM15Izo="
+    },
+    "natives": {
+      "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
+    },
+    "natural-compare": {
+      "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "nave": {
+      "version": "https://registry.npmjs.org/nave/-/nave-0.5.3.tgz",
+      "integrity": "sha1-Ws7HI3WFblx2yDvSGmjXE+tfG6Q="
+    },
+    "negotiator": {
+      "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "netrc": {
+      "version": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
+      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
+      "optional": true
+    },
+    "next-tick": {
+      "version": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+      "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
+    },
+    "no-case": {
+      "version": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
+      "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
+      "requires": {
+        "lower-case": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz"
+      }
+    },
+    "node-gyp": {
+      "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "requires": {
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "semver": {
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        }
+      }
+    },
+    "node-int64": {
+      "version": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+    },
+    "node-notifier": {
+      "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "requires": {
+        "growly": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "shellwords": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+      }
+    },
+    "node-sass": {
+      "version": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+      "requires": {
+        "async-foreach": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+        "gaze": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "in-publish": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+        "lodash.mergewith": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "sass-graph": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+        "stdout-stream": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+          }
+        },
+        "get-stdin": {
+          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "node-sass-utils": {
+      "version": "https://registry.npmjs.org/node-sass-utils/-/node-sass-utils-1.1.2.tgz",
+      "integrity": "sha1-0DY5z6T8liOYujZIq0ZvDbfMITE="
+    },
+    "node-status-codes": {
+      "version": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+    },
+    "noncharacters": {
+      "version": "https://registry.npmjs.org/noncharacters/-/noncharacters-1.1.0.tgz",
+      "integrity": "sha1-rzPfMP1Q7TxTzSAiWPJa2pC1QNI="
+    },
+    "nopt": {
+      "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+      }
+    },
+    "normalize-package-data": {
+      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "requires": {
+        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      }
+    },
+    "normalize-path": {
+      "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+      }
+    },
+    "normalize-pkg": {
+      "version": "https://registry.npmjs.org/normalize-pkg/-/normalize-pkg-0.3.20.tgz",
+      "integrity": "sha1-Luc3FJUXhQ2c7/WmI0r174nFFag=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "map-schema": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+        "parse-git-config": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+        "repo-utils": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "stringify-author": "https://registry.npmjs.org/stringify-author/-/stringify-author-0.1.3.tgz",
+        "write-json": "https://registry.npmjs.org/write-json/-/write-json-0.2.2.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-unique": {
+          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "normalize-range": {
+      "version": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    },
+    "normalize-selector": {
+      "version": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
+    },
+    "normalize-url": {
+      "version": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+        "query-string": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+        "sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
+      }
+    },
+    "now-and-later": {
+      "version": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+      "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      }
+    },
+    "npm-run-path": {
+      "version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "optional": true,
+      "requires": {
+        "path-key": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
+      }
+    },
+    "npmlog": {
+      "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "requires": {
+        "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+      }
+    },
+    "nth-check": {
+      "version": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "requires": {
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+      }
+    },
+    "num2fraction": {
+      "version": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+    },
+    "number-is-nan": {
+      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "nwmatcher": {
+      "version": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
+      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
+    },
+    "oauth-sign": {
+      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-component": {
+      "version": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
+    "object-copy": {
+      "version": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "object-path": {
+      "version": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
+      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU="
+    },
+    "object-visit": {
+      "version": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
+      "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "object.defaults": {
+      "version": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "requires": {
+        "array-each": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+        "array-slice": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+      },
+      "dependencies": {
+        "array-slice": {
+          "version": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+          "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8="
+        },
+        "for-own": {
+          "version": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "requires": {
+            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "object.omit": {
+      "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      }
+    },
+    "object.pick": {
+      "version": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+      "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "omit-empty": {
+      "version": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+      "integrity": "sha1-KUo3gvLLIMdJfEEitiN8ncwMY6s=",
+      "requires": {
+        "has-values": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "reduce-object": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "on-finished": {
+      "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      }
+    },
+    "once": {
+      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
+    },
+    "onecolor": {
+      "version": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.4.tgz",
+      "integrity": "sha1-daRvgNpseqpbTarhekcZi9llJJQ="
+    },
+    "onetime": {
+      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "openurl": {
+      "version": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
+    },
+    "opn": {
+      "version": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
+    },
+    "optimist": {
+      "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        }
+      }
+    },
+    "option-cache": {
+      "version": "https://registry.npmjs.org/option-cache/-/option-cache-3.5.0.tgz",
+      "integrity": "sha1-y3ZRVboqhhwRCf8m4qIOqgZhKys=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "collection-visit": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+        "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+      },
+      "dependencies": {
+        "collection-visit": {
+          "version": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "requires": {
+            "map-visit": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "map-visit": {
+          "version": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "requires": {
+            "object-visit": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+          }
+        },
+        "object-visit": {
+          "version": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+          }
+        }
+      }
+    },
+    "optionator": {
+      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+        }
+      }
+    },
+    "options": {
+      "version": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "optipng-bin": {
+      "version": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.4.tgz",
+      "integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
+      "optional": true,
+      "requires": {
+        "bin-build": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
+        "bin-wrapper": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+        "logalot": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz"
+      }
+    },
+    "orchestrator": {
+      "version": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+      "requires": {
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+        "sequencify": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+        "stream-consume": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          }
+        },
+        "once": {
+          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "ordered-read-streams": {
+      "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+      "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+      "requires": {
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "os-browserify": {
+      "version": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
+    },
+    "os-filter-obj": {
+      "version": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
+      "integrity": "sha1-WRUzDZDs7VV9LZOKMcbdIU2cY60=",
+      "optional": true
+    },
+    "os-homedir": {
+      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      }
+    },
+    "os-tmpdir": {
+      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
+    },
+    "p-finally": {
+      "version": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-limit": {
+      "version": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+    },
+    "p-locate": {
+      "version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
+      }
+    },
+    "p-map": {
+      "version": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
+      "integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
+    },
+    "p-pipe": {
+      "version": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+      "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k="
+    },
+    "p-retry": {
+      "version": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz",
+      "integrity": "sha1-OSczKkt9cCabU1UVEX/FR9oaaWg=",
+      "optional": true,
+      "requires": {
+        "retry": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz"
+      }
+    },
+    "package-json": {
+      "version": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "requires": {
+        "got": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+        "registry-auth-token": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+        "registry-url": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+      }
+    },
+    "pad-right": {
+      "version": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+      "requires": {
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      }
+    },
+    "paginationator": {
+      "version": "https://registry.npmjs.org/paginationator/-/paginationator-0.1.4.tgz",
+      "integrity": "sha1-hHht04UKrh8Ru7kRsMHghRtTgQY="
+    },
+    "pako": {
+      "version": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+    },
+    "parents": {
+      "version": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "requires": {
+        "path-platform": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+      }
+    },
+    "parse-asn1": {
+      "version": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "requires": {
+        "asn1.js": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+        "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+        "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz"
+      }
+    },
+    "parse-author": {
+      "version": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
+      "integrity": "sha1-XsFZAGKXe9nLOWLpFzuHWGQ39d8="
+    },
+    "parse-filepath": {
+      "version": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+      "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+      "requires": {
+        "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+        "map-cache": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+        "path-root": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz"
+      }
+    },
+    "parse-git-config": {
+      "version": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+      "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+        "git-config-path": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+      }
+    },
+    "parse-github-url": {
+      "version": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
+      "integrity": "sha1-du8B6/4LHpwPSTZylSzGpM2csmA="
+    },
+    "parse-glob": {
+      "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+        "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "parse-json": {
+      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+      }
+    },
+    "parse-passwd": {
+      "version": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
+    "parse-repo": {
+      "version": "https://registry.npmjs.org/parse-repo/-/parse-repo-1.0.1.tgz",
+      "integrity": "sha1-uKge9HRgZMfYnctgs8dKmtZwByA=",
+      "optional": true
+    },
+    "parse5": {
+      "version": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+    },
+    "parsejson": {
+      "version": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+      "requires": {
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      }
+    },
+    "parseqs": {
+      "version": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      }
+    },
+    "parser-front-matter": {
+      "version": "https://registry.npmjs.org/parser-front-matter/-/parser-front-matter-1.6.4.tgz",
+      "integrity": "sha1-cf4yiKUce4c0Fj83k/P9wksKipA=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "file-is-binary": "https://registry.npmjs.org/file-is-binary/-/file-is-binary-1.0.0.tgz",
+        "gray-matter": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.0.2.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "trim-leading-lines": "https://registry.npmjs.org/trim-leading-lines/-/trim-leading-lines-0.1.1.tgz"
+      }
+    },
+    "parseuri": {
+      "version": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      }
+    },
+    "parseurl": {
+      "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+    },
+    "pascalcase": {
+      "version": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path-browserify": {
+      "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+    },
+    "path-dirname": {
+      "version": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+    },
+    "path-exists": {
+      "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
+    },
+    "path-is-absolute": {
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+    },
+    "path-key": {
+      "version": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "optional": true
+    },
+    "path-parse": {
+      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "path-platform": {
+      "version": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
+    },
+    "path-root": {
+      "version": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "requires": {
+        "path-root-regex": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
+      }
+    },
+    "path-root-regex": {
+      "version": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+    },
+    "path-to-regexp": {
+      "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "requires": {
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
+    "path-type": {
+      "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
+    },
+    "pbkdf2": {
+      "version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+      "integrity": "sha1-w30pVTHnhrHaPj6tyEBCasywriU=",
+      "requires": {
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      }
+    },
+    "pend": {
+      "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "performance-now": {
+      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "pify": {
+      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+      }
+    },
+    "pipetteur": {
+      "version": "https://registry.npmjs.org/pipetteur/-/pipetteur-2.0.3.tgz",
+      "integrity": "sha1-GVV2CVno0aEcsqUOyD7sRwYz5J8=",
+      "requires": {
+        "onecolor": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.4.tgz",
+        "synesthesia": "https://registry.npmjs.org/synesthesia/-/synesthesia-1.0.1.tgz"
+      }
+    },
+    "pkg-dir": {
+      "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+      }
+    },
+    "pkg-store": {
+      "version": "https://registry.npmjs.org/pkg-store/-/pkg-store-0.2.2.tgz",
+      "integrity": "sha1-sfXA+GIKWf1mWGrMXiVvTCw3oNg=",
+      "requires": {
+        "cache-base": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+        "union-value": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
+        "write-json": "https://registry.npmjs.org/write-json/-/write-json-0.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "plugin-error": {
+      "version": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "requires": {
+        "ansi-cyan": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+        "ansi-red": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "array-slice": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+          }
+        },
+        "extend-shallow": {
+          "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        }
+      }
+    },
+    "plur": {
+      "version": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz"
+      }
+    },
+    "pluralize": {
+      "version": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I="
+    },
+    "portscanner": {
+      "version": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "is-number-like": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz"
+      }
+    },
+    "posix-character-classes": {
+      "version": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "postcss": {
+      "version": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+      "integrity": "sha1-iQZ6nOixH4qEy8URfvwwQZoIV7M=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "requires": {
+            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+          }
+        },
+        "chalk": {
+          "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-assets": {
+      "version": "https://registry.npmjs.org/postcss-assets/-/postcss-assets-4.2.0.tgz",
+      "integrity": "sha1-iqHLs0QmR/hyPiTmahu2JPFVzYQ=",
+      "requires": {
+        "assets": "https://registry.npmjs.org/assets/-/assets-2.1.0.tgz",
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-functions": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-2.1.1.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-calc": {
+      "version": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-message-helpers": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+        "reduce-css-calc": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-colormin": {
+      "version": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+      "requires": {
+        "colormin": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-convert-values": {
+      "version": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-discard-unused": {
+      "version": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-filter-plugins": {
+      "version": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "uniqid": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-functions": {
+      "version": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-2.1.1.tgz",
+      "integrity": "sha1-+bZNO1aQ9nlf5CoYBJaAU3W3qEA=",
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-less": {
+      "version": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
+      "integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-load-config": {
+      "version": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+      "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+      "requires": {
+        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss-load-options": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+        "postcss-load-plugins": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz"
+      }
+    },
+    "postcss-load-options": {
+      "version": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+      "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+      "requires": {
+        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "postcss-load-plugins": {
+      "version": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+      "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+      "requires": {
+        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "postcss-media-query-parser": {
+      "version": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
+    },
+    "postcss-merge-idents": {
+      "version": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "caniuse-api": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+        "vendors": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "requires": {
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
+          }
+        },
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-message-helpers": {
+      "version": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
+    },
+    "postcss-minify-font-values": {
+      "version": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-minify-params": {
+      "version": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+      "requires": {
+        "is-absolute-url": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+        "normalize-url": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-reduce-idents": {
+      "version": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-reporter": {
+      "version": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-4.0.0.tgz",
+      "integrity": "sha1-EzVsNlw2eDrd6I4o4J27puxsZQE=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+      }
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
+    },
+    "postcss-scss": {
+      "version": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.2.tgz",
+      "integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "requires": {
+        "flatten": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+        "indexes-of": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+        "uniq": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+      }
+    },
+    "postcss-svgo": {
+      "version": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+      "requires": {
+        "is-svg": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "postcss-value-parser": {
+      "version": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+    },
+    "postcss-zindex": {
+      "version": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "prelude-ls": {
+      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "prepend-http": {
+      "version": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "preserve": {
+      "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "pretty-bytes": {
+      "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
+      "requires": {
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        }
+      }
+    },
+    "pretty-format": {
+      "version": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+      "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "requires": {
+            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+          }
+        }
+      }
+    },
+    "pretty-hrtime": {
+      "version": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+    },
+    "pretty-time": {
+      "version": "https://registry.npmjs.org/pretty-time/-/pretty-time-0.2.0.tgz",
+      "integrity": "sha1-ejvexAScYgzXxCt/NCt01W5z104=",
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "nanoseconds": "https://registry.npmjs.org/nanoseconds/-/nanoseconds-0.1.0.tgz"
+      }
+    },
+    "private": {
+      "version": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+    },
+    "process": {
+      "version": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "process-nextick-args": {
+      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+    },
+    "project-name": {
+      "version": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+      "integrity": "sha1-Pk94H+HulLB4apuuU1BjdsN5r2k=",
+      "requires": {
+        "find-pkg": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+        "git-repo-name": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+      }
+    },
+    "prr": {
+      "version": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+    },
+    "pseudomap": {
+      "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "public-encrypt": {
+      "version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
+    },
+    "punycode": {
+      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+    },
+    "qs": {
+      "version": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+      "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU="
+    },
+    "query-string": {
+      "version": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "strict-uri-encode": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+      }
+    },
+    "querystring": {
+      "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "querystring-es3": {
+      "version": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+    },
+    "question-cache": {
+      "version": "https://registry.npmjs.org/question-cache/-/question-cache-0.7.0.tgz",
+      "integrity": "sha1-KcX30pCInafGuzlTQutx9x6BPU0=",
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "async-each-series": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
+        "clone-deep": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+        "inquirer2": "https://registry.npmjs.org/inquirer2/-/inquirer2-0.1.1.tgz",
+        "is-answer": "https://registry.npmjs.org/is-answer/-/is-answer-0.1.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+        "option-cache": "https://registry.npmjs.org/option-cache/-/option-cache-3.5.0.tgz",
+        "project-name": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+        "to-choices": "https://registry.npmjs.org/to-choices/-/to-choices-0.2.0.tgz",
+        "use": "https://registry.npmjs.org/use/-/use-2.0.2.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "set-value": {
+          "version": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz"
+          }
+        },
+        "to-object-path": {
+          "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
+          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "is-arguments": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.2.tgz"
+          }
+        },
+        "use": {
+          "version": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+          "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+          "requires": {
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+            "isobject": "3.0.1",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        }
+      }
+    },
+    "question-store": {
+      "version": "https://registry.npmjs.org/question-store/-/question-store-0.13.1.tgz",
+      "integrity": "sha1-x10lV0KNcS5+CPNUE0IV+zqc768=",
+      "requires": {
+        "common-config": "https://registry.npmjs.org/common-config/-/common-config-0.1.0.tgz",
+        "data-store": "https://registry.npmjs.org/data-store/-/data-store-0.16.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "is-answer": "https://registry.npmjs.org/is-answer/-/is-answer-0.1.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "project-name": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+        "question-cache": "https://registry.npmjs.org/question-cache/-/question-cache-0.7.0.tgz"
+      }
+    },
+    "randomatic": {
+      "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "randombytes": {
+      "version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
+    },
+    "range-parser": {
+      "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "rc": {
+      "version": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "requires": {
+        "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+      }
+    },
+    "read-all-stream": {
+      "version": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "requires": {
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "read-file": {
+      "version": "https://registry.npmjs.org/read-file/-/read-file-0.2.0.tgz",
+      "integrity": "sha1-cMa6+IQux9FUD5gf0Oau1Mgb1UU="
+    },
+    "read-file-stdin": {
+      "version": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz",
+      "integrity": "sha1-JezP86FTtoCa+ssj7hU4fbng7mE=",
+      "requires": {
+        "gather-stream": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz"
+      }
+    },
+    "read-only-stream": {
+      "version": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "read-pkg": {
+      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+      }
+    },
+    "read-pkg-up": {
+      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+      }
+    },
+    "readable-stream": {
+      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "requires": {
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      }
+    },
+    "readdirp": {
+      "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+      }
+    },
+    "readline2": {
+      "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "requires": {
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+      }
+    },
+    "rechoir": {
+      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      }
+    },
+    "redent": {
+      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "requires": {
+        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+        "math-expression-evaluator": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+        "reduce-function-call": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
+      }
+    },
+    "reduce-object": {
+      "version": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
+      "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
+      "requires": {
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz"
+      }
+    },
+    "regenerate": {
+      "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+    },
+    "regenerator-runtime": {
+      "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+    },
+    "regenerator-transform": {
+      "version": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+      }
+    },
+    "regex-cache": {
+      "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "requires": {
+        "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      }
+    },
+    "regex-flags": {
+      "version": "https://registry.npmjs.org/regex-flags/-/regex-flags-0.1.0.tgz",
+      "integrity": "sha1-NEJ5hCj6rtU7DP7ef1cEQRDtHpQ=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "regex-not": {
+      "version": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+      }
+    },
+    "regexpu-core": {
+      "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "requires": {
+        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+        "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+        "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+      }
+    },
+    "registry-auth-token": {
+      "version": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "requires": {
+        "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
+    },
+    "registry-url": {
+      "version": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "requires": {
+        "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz"
+      }
+    },
+    "regjsgen": {
+      "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+    },
+    "regjsparser": {
+      "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "requires": {
+        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+        }
+      }
+    },
+    "relative": {
+      "version": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+      "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "release-it": {
+      "version": "https://registry.npmjs.org/release-it/-/release-it-2.8.5.tgz",
+      "integrity": "sha1-0REAc1UGH4jNpp9y1zy8imSkks8=",
+      "optional": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "github": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "p-retry": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz",
+        "parse-repo": "https://registry.npmjs.org/parse-repo/-/parse-repo-1.0.1.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+        "when": "https://registry.npmjs.org/when/-/when-3.7.8.tgz"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "optional": true
+        },
+        "cli-cursor": {
+          "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "optional": true,
+          "requires": {
+            "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz"
+          }
+        },
+        "cli-width": {
+          "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+          "optional": true
+        },
+        "figures": {
+          "version": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "optional": true,
+          "requires": {
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "optional": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "inquirer": {
+          "version": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+          "optional": true,
+          "requires": {
+            "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+            "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
+            "figures": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "run-async": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
+        },
+        "mute-stream": {
+          "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "optional": true
+        },
+        "onetime": {
+          "version": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "optional": true,
+          "requires": {
+            "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
+          }
+        },
+        "restore-cursor": {
+          "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "optional": true,
+          "requires": {
+            "onetime": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+          }
+        },
+        "run-async": {
+          "version": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "optional": true,
+          "requires": {
+            "is-promise": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
+          }
+        },
+        "semver": {
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "optional": true
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "optional": true,
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "optional": true,
+              "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+              }
+            }
+          }
+        }
+      }
+    },
+    "remarkable": {
+      "version": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+        "autolinker": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+          "requires": {
+            "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+            "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+          }
+        }
+      }
+    },
+    "remote-origin-url": {
+      "version": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.3.tgz",
+      "integrity": "sha1-ufxs7SyCZpDQsHIYsrjBf87Ijoc=",
+      "requires": {
+        "parse-git-config": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+    },
+    "repeat-element": {
+      "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "repeating": {
+      "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+      }
+    },
+    "replace-ext": {
+      "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+    },
+    "repo-utils": {
+      "version": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
+      "integrity": "sha1-SrZq80DLEfp+XPgFgekr6Xwb964=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "git-config-path": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+        "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "omit-empty": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+        "parse-author": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
+        "parse-git-config": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+        "parse-github-url": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
+        "project-name": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "request": {
+      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "requires": {
+        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+        "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        }
+      }
+    },
+    "require-dir": {
+      "version": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
+      "integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
+    },
+    "require-directory": {
+      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-from-string": {
+      "version": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+    },
+    "require-main-filename": {
+      "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "require-uncached": {
+      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "requires": {
+        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+      }
+    },
+    "requires-port": {
+      "version": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resolve": {
+      "version": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
+      "requires": {
+        "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+      }
+    },
+    "resolve-dir": {
+      "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "requires": {
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+        "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz"
+      },
+      "dependencies": {
+        "global-modules": {
+          "version": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
+          "requires": {
+            "global-prefix": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+            "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+    },
+    "resolve-glob": {
+      "version": "https://registry.npmjs.org/resolve-glob/-/resolve-glob-1.0.0.tgz",
+      "integrity": "sha1-xhQrD4UDZ2B6ridQa+eYXTqMaTE=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+        "matched": "https://registry.npmjs.org/matched/-/matched-1.0.2.tgz",
+        "relative": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz"
+      },
+      "dependencies": {
+        "is-valid-glob": {
+          "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+          "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
+        }
+      }
+    },
+    "resolve-url": {
+      "version": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "resp-modifier": {
+      "version": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+      "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+      }
+    },
+    "restore-cursor": {
+      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "requires": {
+        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+      }
+    },
+    "rethrow": {
+      "version": "https://registry.npmjs.org/rethrow/-/rethrow-0.2.3.tgz",
+      "integrity": "sha1-xVKPGQ6J7HU1iJRSob5omWtfZhY=",
+      "requires": {
+        "ansi-bgred": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
+        "ansi-red": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+        "ansi-yellow": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
+      }
+    },
+    "retry": {
+      "version": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "optional": true
+    },
+    "rev-hash": {
+      "version": "https://registry.npmjs.org/rev-hash/-/rev-hash-1.0.0.tgz",
+      "integrity": "sha1-lpk5Weqb+xxZsTrfAqwuNLs3NgM="
+    },
+    "rev-path": {
+      "version": "https://registry.npmjs.org/rev-path/-/rev-path-1.0.0.tgz",
+      "integrity": "sha1-1My0NqwzcMRgcXXOiOr8XGXF1lM=",
+      "requires": {
+        "modify-filename": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz"
+      }
+    },
+    "rewrite-ext": {
+      "version": "https://registry.npmjs.org/rewrite-ext/-/rewrite-ext-0.2.0.tgz",
+      "integrity": "sha1-WzWLRHLU9UTnA2w3sGYwZJLt17Q=",
+      "requires": {
+        "ext-map": "https://registry.npmjs.org/ext-map/-/ext-map-1.0.1.tgz"
+      }
+    },
+    "right-align": {
+      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+      }
+    },
+    "rimraf": {
+      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "ripemd160": {
+      "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "requires": {
+        "hash-base": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "rocambole": {
+      "version": "https://registry.npmjs.org/rocambole/-/rocambole-0.5.1.tgz",
+      "integrity": "sha1-MEj2SyOIuN2Okz+a1EPws4mrYI8=",
+      "requires": {
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        }
+      }
+    },
+    "rocambole-node-remove": {
+      "version": "https://registry.npmjs.org/rocambole-node-remove/-/rocambole-node-remove-1.0.0.tgz",
+      "integrity": "sha1-vUmxPb5hInWDdP/SR9inOeghSG8=",
+      "requires": {
+        "rocambole-token": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+      }
+    },
+    "rocambole-node-update": {
+      "version": "https://registry.npmjs.org/rocambole-node-update/-/rocambole-node-update-1.0.1.tgz",
+      "integrity": "sha1-o//JaLDzvNnPKpM23A234lTIPFo=",
+      "requires": {
+        "rocambole-token": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+      }
+    },
+    "rocambole-strip-alert": {
+      "version": "https://registry.npmjs.org/rocambole-strip-alert/-/rocambole-strip-alert-1.0.0.tgz",
+      "integrity": "sha1-OyVf5vGNYwH4BaFOVwsfHy26hX8=",
+      "requires": {
+        "rocambole-node-update": "https://registry.npmjs.org/rocambole-node-update/-/rocambole-node-update-1.0.1.tgz"
+      }
+    },
+    "rocambole-strip-console": {
+      "version": "https://registry.npmjs.org/rocambole-strip-console/-/rocambole-strip-console-1.0.0.tgz",
+      "integrity": "sha1-K5fj36bhnUUo6+galCMdyeiqygs=",
+      "requires": {
+        "rocambole-node-update": "https://registry.npmjs.org/rocambole-node-update/-/rocambole-node-update-1.0.1.tgz"
+      }
+    },
+    "rocambole-strip-debugger": {
+      "version": "https://registry.npmjs.org/rocambole-strip-debugger/-/rocambole-strip-debugger-1.0.0.tgz",
+      "integrity": "sha1-HFUCQgw9bvXiOnC4BUff0dS7y3Y=",
+      "requires": {
+        "rocambole-node-remove": "https://registry.npmjs.org/rocambole-node-remove/-/rocambole-node-remove-1.0.0.tgz"
+      }
+    },
+    "rocambole-token": {
+      "version": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz",
+      "integrity": "sha1-x4XfdCjcPLJ614lwR71SOMwHDTU="
+    },
+    "run-async": {
+      "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      }
+    },
+    "run-sequence": {
+      "version": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+      "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+      }
+    },
+    "rx": {
+      "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+    },
+    "rx-lite": {
+      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz"
+      }
+    },
+    "safe-buffer": {
+      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+    },
+    "safe-json-stringify": {
+      "version": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
+      "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE="
+    },
+    "sane": {
+      "version": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
+      "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+      "requires": {
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+        "exec-sh": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
+        "fb-watchman": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "walker": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+        "watch": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
+      },
+      "dependencies": {
+        "bser": {
+          "version": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+          "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+          "requires": {
+            "node-int64": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
+          }
+        },
+        "fb-watchman": {
+          "version": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
+          "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+          "requires": {
+            "bser": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "sass-graph": {
+      "version": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "scss-tokenizer": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "yargs": {
+          "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+          }
+        },
+        "yargs-parser": {
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          }
+        }
+      }
+    },
+    "sax": {
+      "version": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+    },
+    "scss-tokenizer": {
+      "version": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "requires": {
+        "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+      }
+    },
+    "seek-bzip": {
+      "version": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+    },
+    "semver-diff": {
+      "version": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "requires": {
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+      }
+    },
+    "semver-regex": {
+      "version": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
+      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
+      "optional": true
+    },
+    "semver-truncate": {
+      "version": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+      "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
+      "optional": true,
+      "requires": {
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+      }
+    },
+    "send": {
+      "version": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
+      "integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+        "ms": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+          "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+              "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+            }
+          }
+        },
+        "fresh": {
+          "version": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+          "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+        },
+        "http-errors": {
+          "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "requires": {
+            "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
+        },
+        "mime": {
+          "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
+          "integrity": "sha1-Wa3NIu3FQ/e1OBhi0xOHsfS8lHM="
+        },
+        "setprototypeof": {
+          "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+        }
+      }
+    },
+    "sequencify": {
+      "version": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
+    },
+    "serve-index": {
+      "version": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
+      "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+        "batch": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
+      "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
+      "requires": {
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "send": "https://registry.npmjs.org/send/-/send-0.15.2.tgz"
+      }
+    },
+    "server-destroy": {
+      "version": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+    },
+    "serviceworker-cache-polyfill": {
+      "version": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
+    },
+    "set-blocking": {
+      "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-getter": {
+      "version": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "requires": {
+        "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+      }
+    },
+    "set-immediate-shim": {
+      "version": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "set-value": {
+      "version": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+      "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+        "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+        "to-object-path": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+      }
+    },
+    "setprototypeof": {
+      "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+      "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
+    },
+    "sha.js": {
+      "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "shallow-clone": {
+      "version": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "requires": {
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+        "mixin-object": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
+      }
+    },
+    "shasum": {
+      "version": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+      "requires": {
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      },
+      "dependencies": {
+        "json-stable-stringify": {
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+          "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+          "requires": {
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+          }
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+      }
+    },
+    "shebang-regex": {
+      "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-quote": {
+      "version": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "requires": {
+        "array-filter": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+        "array-map": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+        "array-reduce": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      }
+    },
+    "shelljs": {
+      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "optional": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "optional": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
+    },
+    "shellwords": {
+      "version": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
+      "integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ="
+    },
+    "sigmund": {
+      "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+    },
+    "signal-exit": {
+      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slash": {
+      "version": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "slice-ansi": {
+      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+    },
+    "slide": {
+      "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
+    "snapdragon": {
+      "version": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "requires": {
+        "base": "https://registry.npmjs.org/base/-/base-0.11.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "map-cache": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "source-map-resolve": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.0.tgz",
+        "use": "https://registry.npmjs.org/use/-/use-2.0.2.tgz"
+      },
+      "dependencies": {
+        "atob": {
+          "version": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+          "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "source-map-resolve": {
+          "version": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.0.tgz",
+          "integrity": "sha1-/K0LZLcK+ydpnkJZUMtevNQQvCA=",
+          "requires": {
+            "atob": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+            "resolve-url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "source-map-url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+          }
+        },
+        "source-map-url": {
+          "version": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "use": {
+          "version": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+          "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+          "requires": {
+            "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "snapdragon-util": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz"
+          }
+        },
+        "is-descriptor": {
+          "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+          "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
+          "requires": {
+            "is-accessor-descriptor": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "is-data-descriptor": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "sntp": {
+      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
+    },
+    "socket.io": {
+      "version": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
+      "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "socket.io-adapter": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+        "socket.io-client": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        },
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
+      }
+    },
+    "socket.io-client": {
+      "version": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+      "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
+      "requires": {
+        "backo2": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+        "component-bind": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-client": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "object-component": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+        "parseuri": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+        "to-array": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
+      "requires": {
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+        },
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+      }
+    },
+    "sort-object-arrays": {
+      "version": "https://registry.npmjs.org/sort-object-arrays/-/sort-object-arrays-0.1.1.tgz",
+      "integrity": "sha1-mfVc8gWkkd3h9S8Jajaiawm0gy8=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+      }
+    },
+    "source-map-resolve": {
+      "version": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "requires": {
+        "atob": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+        "resolve-url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+        "source-map-url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+        "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+      }
+    },
+    "source-map-support": {
+      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
+    },
+    "sparkles": {
+      "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+    },
+    "spdx-correct": {
+      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+    },
+    "spdx-license-ids": {
+      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+    },
+    "specificity": {
+      "version": "https://registry.npmjs.org/specificity/-/specificity-0.3.1.tgz",
+      "integrity": "sha1-8bBoQkzjF64HR42V3jwhz4Xo1Wc="
+    },
+    "split-string": {
+      "version": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz",
+      "integrity": "sha1-YSm8knMXFuWqH7c8MzB48LfBFMg=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+      }
+    },
+    "split2": {
+      "version": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
+      "integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "squeak": {
+      "version": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
+      "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
+      "optional": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "console-stream": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
+        "lpad-align": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz"
+      }
+    },
+    "src-stream": {
+      "version": "https://registry.npmjs.org/src-stream/-/src-stream-0.1.1.tgz",
+      "integrity": "sha1-2T9G0oGjcAKB7A8wszoDFDiUpoE=",
+      "requires": {
+        "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+        "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "merge-stream": {
+          "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
+          "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
+          "requires": {
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "sshpk": {
+      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "stat-mode": {
+      "version": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
+    },
+    "static-extend": {
+      "version": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "object-copy": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz"
+      }
+    },
+    "statuses": {
+      "version": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stdout-stream": {
+      "version": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "stream-browserify": {
+      "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "stream-combiner": {
+      "version": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "requires": {
+        "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
+    "stream-combiner2": {
+      "version": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "requires": {
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "stream-consume": {
+      "version": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
+    },
+    "stream-counter": {
+      "version": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
+      "integrity": "sha1-kc8lac5NxQYf6816yyY5SloRR1E="
+    },
+    "stream-exhaust": {
+      "version": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.1.tgz",
+      "integrity": "sha1-wMRFXlTOWhecqHNuczNLTn/WdVM="
+    },
+    "stream-http": {
+      "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
+      "requires": {
+        "builtin-status-codes": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "to-arraybuffer": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "stream-shift": {
+      "version": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
+    "stream-splicer": {
+      "version": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "stream-throttle": {
+      "version": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+        "limiter": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz"
+      }
+    },
+    "strict-uri-encode": {
+      "version": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
+    },
+    "string-length": {
+      "version": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+      "requires": {
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "string-width": {
+      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "stringify-author": {
+      "version": "https://registry.npmjs.org/stringify-author/-/stringify-author-0.1.3.tgz",
+      "integrity": "sha1-1YHgLOC1XNo8lT5irdIR+uSw72Y="
+    },
+    "stringify-object": {
+      "version": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.0.tgz",
+      "integrity": "sha1-lDcKE15BvASDWIE7+ZSB8TFcaqY=",
+      "requires": {
+        "get-own-enumerable-property-symbols": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-1.0.1.tgz",
+        "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+        "is-regexp": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz"
+      }
+    },
+    "stringstream": {
+      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+      }
+    },
+    "strip-bom": {
+      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      }
+    },
+    "strip-bom-buffer": {
+      "version": "https://registry.npmjs.org/strip-bom-buffer/-/strip-bom-buffer-0.1.1.tgz",
+      "integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
+      "requires": {
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      }
+    },
+    "strip-bom-stream": {
+      "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+      "requires": {
+        "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      }
+    },
+    "strip-bom-string": {
+      "version": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-0.1.2.tgz",
+      "integrity": "sha1-nG5yCjE7qYNliVGEBcz7iKX0G5w="
+    },
+    "strip-color": {
+      "version": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s="
+    },
+    "strip-debug": {
+      "version": "https://registry.npmjs.org/strip-debug/-/strip-debug-1.1.1.tgz",
+      "integrity": "sha1-aYJBmGdp3O9RPcbHymKbBryfIXs=",
+      "requires": {
+        "rocambole": "https://registry.npmjs.org/rocambole/-/rocambole-0.5.1.tgz",
+        "rocambole-strip-alert": "https://registry.npmjs.org/rocambole-strip-alert/-/rocambole-strip-alert-1.0.0.tgz",
+        "rocambole-strip-console": "https://registry.npmjs.org/rocambole-strip-console/-/rocambole-strip-console-1.0.0.tgz",
+        "rocambole-strip-debugger": "https://registry.npmjs.org/rocambole-strip-debugger/-/rocambole-strip-debugger-1.0.0.tgz"
+      }
+    },
+    "strip-dirs": {
+      "version": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+      "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+        "is-natural-number": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "sum-up": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "is-absolute": {
+          "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+          "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+          "requires": {
+            "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+          }
+        },
+        "is-relative": {
+          "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+          "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI="
+        }
+      }
+    },
+    "strip-eof": {
+      "version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "optional": true
+    },
+    "strip-indent": {
+      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "requires": {
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "strip-outer": {
+      "version": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+      "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
+      "requires": {
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+      }
+    },
+    "striptags": {
+      "version": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+      "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI="
+    },
+    "style-search": {
+      "version": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
+    },
+    "stylehacks": {
+      "version": "https://registry.npmjs.org/stylehacks/-/stylehacks-2.3.2.tgz",
+      "integrity": "sha1-ZMg+BDimjJ7fRJ6MVSp9mrYAmws=",
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "plur": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-reporter": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
+        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+        "read-file-stdin": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "write-file-stdout": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "requires": {
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
+          }
+        },
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "postcss-reporter": {
+          "version": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
+          "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "stylelint": {
+      "version": "https://registry.npmjs.org/stylelint/-/stylelint-7.13.0.tgz",
+      "integrity": "sha1-ER+Xttpy53XICADWu29fhpmXeF0=",
+      "requires": {
+        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+        "colorguard": "https://registry.npmjs.org/colorguard/-/colorguard-1.2.0.tgz",
+        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "doiuse": "https://registry.npmjs.org/doiuse/-/doiuse-2.6.0.tgz",
+        "execall": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+        "globby": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+        "globjoin": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+        "html-tags": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "known-css-properties": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+        "mathml-tag-names": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "normalize-selector": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-less": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
+        "postcss-media-query-parser": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+        "postcss-reporter": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-3.0.0.tgz",
+        "postcss-resolve-nested-selector": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+        "postcss-scss": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.4.1.tgz",
+        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+        "specificity": "https://registry.npmjs.org/specificity/-/specificity-0.3.1.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+        "style-search": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+        "stylehacks": "https://registry.npmjs.org/stylehacks/-/stylehacks-2.3.2.tgz",
+        "sugarss": "https://registry.npmjs.org/sugarss/-/sugarss-0.2.0.tgz",
+        "svg-tags": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+        "table": "https://registry.npmjs.org/table/-/table-4.0.1.tgz"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "autoprefixer": {
+          "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+          "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+          "requires": {
+            "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+            "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+          }
+        },
+        "balanced-match": {
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "browserslist": {
+          "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "requires": {
+            "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
+          }
+        },
+        "chalk": {
+          "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+              "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+              "requires": {
+                "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+              }
+            },
+            "has-flag": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+            },
+            "supports-color": {
+              "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+              "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "globby": {
+          "version": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
+        },
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "1.1.3",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                }
+              }
+            }
+          }
+        },
+        "postcss-reporter": {
+          "version": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-3.0.0.tgz",
+          "integrity": "sha1-CeoPN6RExWk4eGBuCbAY6+/3z48=",
+          "requires": {
+            "chalk": "1.1.3",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "log-symbols": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "supports-color": "2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "postcss-scss": {
+          "version": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.4.1.tgz",
+          "integrity": "sha1-rXcbgfD3L19IRdCKpg+TVXZT1Uw=",
+          "requires": {
+            "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+          }
+        },
+        "resolve-from": {
+          "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "subarg": {
+      "version": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+      }
+    },
+    "success-symbol": {
+      "version": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+      "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc="
+    },
+    "sugarss": {
+      "version": "https://registry.npmjs.org/sugarss/-/sugarss-0.2.0.tgz",
+      "integrity": "sha1-rDQjdWMyfG/4l7ZHQr9q7BkK054=",
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          }
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "sum-up": {
+      "version": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
+      "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      }
+    },
+    "supports-color": {
+      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "svg-tags": {
+      "version": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
+    },
+    "svgo": {
+      "version": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+      "requires": {
+        "coa": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+        "colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+        "csso": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "whet.extend": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        },
+        "js-yaml": {
+          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+          "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+          "requires": {
+            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+          }
+        }
+      }
+    },
+    "sw-precache": {
+      "version": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.0.tgz",
+      "integrity": "sha1-62IlzlgM6q4UgZRXigrQGrfqGZw=",
+      "requires": {
+        "dom-urls": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+        "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "pretty-bytes": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+        "sw-toolbox": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+        "update-notifier": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "lodash.template": {
+          "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+          }
+        },
+        "pretty-bytes": {
+          "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+          "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+        }
+      }
+    },
+    "sw-toolbox": {
+      "version": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+      "requires": {
+        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+        "serviceworker-cache-polyfill": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz"
+      }
+    },
+    "symbol-tree": {
+      "version": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+    },
+    "synesthesia": {
+      "version": "https://registry.npmjs.org/synesthesia/-/synesthesia-1.0.1.tgz",
+      "integrity": "sha1-XvlepUjA1cbm+btLDQcx3/hkp3c=",
+      "requires": {
+        "css-color-names": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
+      },
+      "dependencies": {
+        "css-color-names": {
+          "version": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
+          "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY="
+        }
+      }
+    },
+    "syntax-error": {
+      "version": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+      "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+      }
+    },
+    "table": {
+      "version": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
+      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "requires": {
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          }
+        },
+        "strip-ansi": {
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+          }
+        }
+      }
+    },
+    "tableize-object": {
+      "version": "https://registry.npmjs.org/tableize-object/-/tableize-object-0.1.0.tgz",
+      "integrity": "sha1-fCngEzsn1ItWuedtOijSQd8bOiQ=",
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "tar": {
+      "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "tar-stream": {
+      "version": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "requires": {
+        "bl": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "temp-dir": {
+      "version": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "optional": true
+    },
+    "tempfile": {
+      "version": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+      "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+      "optional": true,
+      "requires": {
+        "temp-dir": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+      }
+    },
+    "template-error": {
+      "version": "https://registry.npmjs.org/template-error/-/template-error-0.1.2.tgz",
+      "integrity": "sha1-GMn2ANkPLz37oIM+N/fLb0E1QtQ=",
+      "requires": {
+        "engine": "https://registry.npmjs.org/engine/-/engine-0.1.12.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+        "rethrow": "https://registry.npmjs.org/rethrow/-/rethrow-0.2.3.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
+      }
+    },
+    "templates": {
+      "version": "https://registry.npmjs.org/templates/-/templates-1.2.9.tgz",
+      "integrity": "sha1-2LDecdaTMa91XLCVM7TswtpkmAE=",
+      "requires": {
+        "array-sort": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.3.tgz",
+        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+        "base": "https://registry.npmjs.org/base/-/base-0.11.1.tgz",
+        "base-data": "https://registry.npmjs.org/base-data/-/base-data-0.6.2.tgz",
+        "base-engines": "https://registry.npmjs.org/base-engines/-/base-engines-0.2.1.tgz",
+        "base-helpers": "https://registry.npmjs.org/base-helpers/-/base-helpers-0.2.0.tgz",
+        "base-option": "https://registry.npmjs.org/base-option/-/base-option-0.8.4.tgz",
+        "base-plugins": "https://registry.npmjs.org/base-plugins/-/base-plugins-0.4.13.tgz",
+        "base-routes": "https://registry.npmjs.org/base-routes/-/base-routes-0.2.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "deep-bind": "https://registry.npmjs.org/deep-bind/-/deep-bind-0.3.0.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "engine-base": "https://registry.npmjs.org/engine-base/-/engine-base-0.1.3.tgz",
+        "export-files": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "falsey": "https://registry.npmjs.org/falsey/-/falsey-0.3.0.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "get-view": "https://registry.npmjs.org/get-view/-/get-view-0.1.3.tgz",
+        "group-array": "https://registry.npmjs.org/group-array/-/group-array-0.3.3.tgz",
+        "has-glob": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+        "inflection": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+        "is-valid-app": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+        "layouts": "https://registry.npmjs.org/layouts/-/layouts-0.12.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "match-file": "https://registry.npmjs.org/match-file/-/match-file-0.2.2.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+        "paginationator": "https://registry.npmjs.org/paginationator/-/paginationator-0.1.4.tgz",
+        "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+        "template-error": "https://registry.npmjs.org/template-error/-/template-error-0.1.2.tgz",
+        "vinyl-item": "https://registry.npmjs.org/vinyl-item/-/vinyl-item-1.0.0.tgz",
+        "vinyl-view": "https://registry.npmjs.org/vinyl-view/-/vinyl-view-2.0.1.tgz"
+      },
+      "dependencies": {
+        "is-valid-app": {
+          "version": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
+          "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "is-registered": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
+            "is-valid-instance": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
+          }
+        },
+        "is-valid-instance": {
+          "version": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
+          "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
+          "requires": {
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "pascalcase": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+          }
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "ternary-stream": {
+      "version": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+      "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+      "requires": {
+        "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+        "fork-stream": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+        "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "test-exclude": {
+      "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+      "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+      "requires": {
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+      }
+    },
+    "text-table": {
+      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "tfunk": {
+      "version": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
+      "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "object-path": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
+      }
+    },
+    "throat": {
+      "version": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+      "integrity": "sha1-UMsGcO28QCN7njR9fh+I5GIK+DY="
+    },
+    "through": {
+      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "through2-concurrent": {
+      "version": "https://registry.npmjs.org/through2-concurrent/-/through2-concurrent-1.1.1.tgz",
+      "integrity": "sha1-EctOpMnjG8puTB5tukjRxyjDUks=",
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "through2-filter": {
+      "version": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "tildify": {
+      "version": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
+    },
+    "time-diff": {
+      "version": "https://registry.npmjs.org/time-diff/-/time-diff-0.3.1.tgz",
+      "integrity": "sha1-Jej7c07qnmy15LA5TwWBC5yHwtg=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "log-utils": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
+        "pretty-time": "https://registry.npmjs.org/pretty-time/-/pretty-time-0.2.0.tgz"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
+          "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
+          "requires": {
+            "ansi-bgblack": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
+            "ansi-bgblue": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
+            "ansi-bgcyan": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
+            "ansi-bggreen": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
+            "ansi-bgmagenta": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
+            "ansi-bgred": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
+            "ansi-bgwhite": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
+            "ansi-bgyellow": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
+            "ansi-black": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
+            "ansi-blue": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
+            "ansi-bold": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
+            "ansi-cyan": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "ansi-dim": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
+            "ansi-gray": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "ansi-green": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+            "ansi-grey": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
+            "ansi-hidden": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
+            "ansi-inverse": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
+            "ansi-italic": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
+            "ansi-magenta": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
+            "ansi-red": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "ansi-reset": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
+            "ansi-strikethrough": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
+            "ansi-underline": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
+            "ansi-white": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
+            "ansi-yellow": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        },
+        "log-utils": {
+          "version": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
+          "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
+          "requires": {
+            "ansi-colors": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
+            "error-symbol": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
+            "info-symbol": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
+            "log-ok": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+            "success-symbol": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+            "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "warning-symbol": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz"
+          }
+        }
+      }
+    },
+    "time-stamp": {
+      "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+    },
+    "timed-out": {
+      "version": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+    },
+    "timers-browserify": {
+      "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "requires": {
+        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
+      }
+    },
+    "timers-ext": {
+      "version": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
+      "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
+      "requires": {
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+        "next-tick": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz"
+      },
+      "dependencies": {
+        "next-tick": {
+          "version": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+        }
+      }
+    },
+    "tmp": {
+      "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "requires": {
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
+    },
+    "tmpl": {
+      "version": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+    },
+    "to-absolute-glob": {
+      "version": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+      }
+    },
+    "to-array": {
+      "version": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "to-arraybuffer": {
+      "version": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+    },
+    "to-choices": {
+      "version": "https://registry.npmjs.org/to-choices/-/to-choices-0.2.0.tgz",
+      "integrity": "sha1-IufnWgfWl9fkzsvVaxvwPBVlTXM=",
+      "requires": {
+        "ansi-gray": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+        "mixin-deep": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz"
+      }
+    },
+    "to-fast-properties": {
+      "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "to-gfm-code-block": {
+      "version": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
+      "integrity": "sha1-JdBFpfrlUxielje1kJANpzLYqoI="
+    },
+    "to-object-path": {
+      "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
+      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "regex-not": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz"
+      }
+    },
+    "to-regex-range": {
+      "version": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          }
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      }
+    },
+    "tr46": {
+      "version": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "trim-leading-lines": {
+      "version": "https://registry.npmjs.org/trim-leading-lines/-/trim-leading-lines-0.1.1.tgz",
+      "integrity": "sha1-DnysPoMELc+Vp07TaWbxd0TVwWk=",
+      "requires": {
+        "is-whitespace": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz"
+      }
+    },
+    "trim-newlines": {
+      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "trim-repeated": {
+      "version": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "requires": {
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+      }
+    },
+    "trim-right": {
+      "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "tryit": {
+      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+    },
+    "tty-browserify": {
+      "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "tunnel-agent": {
+      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
+    },
+    "tweetnacl": {
+      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-check": {
+      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+      }
+    },
+    "typedarray": {
+      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typeof-article": {
+      "version": "https://registry.npmjs.org/typeof-article/-/typeof-article-0.1.1.tgz",
+      "integrity": "sha1-nwfnM8P7tkb/qeYcCN66zUYOBq8=",
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
+        }
+      }
+    },
+    "ua-parser-js": {
+      "version": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+      "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs="
+    },
+    "uglify-js": {
+      "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "optional": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
+    },
+    "ultron": {
+      "version": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "umd": {
+      "version": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+      "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4="
+    },
+    "unc-path-regex": {
+      "version": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "underscore": {
+      "version": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "underscore.string": {
+      "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
+    },
+    "union-value": {
+      "version": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
+      "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        }
+      }
+    },
+    "uniq": {
+      "version": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
+    "uniqid": {
+      "version": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+      "requires": {
+        "macaddress": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
+      }
+    },
+    "uniqs": {
+      "version": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+    },
+    "unique-stream": {
+      "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+      "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+      "requires": {
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
+      }
+    },
+    "universalify": {
+      "version": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "unpipe": {
+      "version": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "unset-value": {
+      "version": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
+      "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
+      "requires": {
+        "has-value": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
+      }
+    },
+    "unzip-response": {
+      "version": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+    },
+    "update-notifier": {
+      "version": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+      "requires": {
+        "boxen": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "configstore": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+        "is-npm": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+        "latest-version": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+        "lazy-req": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+        "semver-diff": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+        "xdg-basedir": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
+      }
+    },
+    "upper-case": {
+      "version": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "urijs": {
+      "version": "https://registry.npmjs.org/urijs/-/urijs-1.18.12.tgz",
+      "integrity": "sha1-8E2R4fq7KcFvyEL5oU7o3cP9pk4="
+    },
+    "urix": {
+      "version": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "url-parse-lax": {
+      "version": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
+      }
+    },
+    "url-regex": {
+      "version": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
+      "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
+      "optional": true,
+      "requires": {
+        "ip-regex": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+      }
+    },
+    "use": {
+      "version": "https://registry.npmjs.org/use/-/use-1.1.2.tgz",
+      "integrity": "sha1-bjgy/rholXNJSsanrLX++zd7LNE=",
+      "requires": {
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "user-home": {
+      "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+    },
+    "util": {
+      "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "uuid": {
+      "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+    },
+    "v8flags": {
+      "version": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "requires": {
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+      }
+    },
+    "vali-date": {
+      "version": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+    },
+    "validate-npm-package-license": {
+      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+      }
+    },
+    "vendors": {
+      "version": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+      "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI="
+    },
+    "verror": {
+      "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "vinyl": {
+      "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+      }
+    },
+    "vinyl-assign": {
+      "version": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
+      "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
+    },
+    "vinyl-buffer": {
+      "version": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
+      "integrity": "sha1-ygZ+oIQx1QdyKx3lCD9gJhbrwjQ=",
+      "requires": {
+        "bl": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+          "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+          }
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        }
+      }
+    },
+    "vinyl-file": {
+      "version": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.3.0.tgz",
+      "integrity": "sha1-qgVjTTqGe6kUR77bs0r8sm9E9uc=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      }
+    },
+    "vinyl-fs": {
+      "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+      "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+      "requires": {
+        "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+        "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "gulp-sourcemaps": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+        "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+        "lazystream": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+        "lodash.isequal": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+        "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+        "vali-date": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
+      "dependencies": {
+        "gulp-sourcemaps": {
+          "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+          "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+          "requires": {
+            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+          }
+        }
+      }
+    },
+    "vinyl-item": {
+      "version": "https://registry.npmjs.org/vinyl-item/-/vinyl-item-1.0.0.tgz",
+      "integrity": "sha1-5BiPq3lRVN6edFiOqtPfS6UVFpI=",
+      "requires": {
+        "base": "https://registry.npmjs.org/base/-/base-0.11.1.tgz",
+        "base-option": "https://registry.npmjs.org/base-option/-/base-option-0.8.4.tgz",
+        "base-plugins": "https://registry.npmjs.org/base-plugins/-/base-plugins-0.4.13.tgz",
+        "clone": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+        },
+        "clone-stats": {
+          "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+        },
+        "replace-ext": {
+          "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+            "clone-buffer": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "cloneable-readable": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
+          }
+        }
+      }
+    },
+    "vinyl-source-stream": {
+      "version": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+      "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        },
+        "vinyl": {
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
+        }
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "vinyl-view": {
+      "version": "https://registry.npmjs.org/vinyl-view/-/vinyl-view-2.0.1.tgz",
+      "integrity": "sha1-RqTZn6hoi/N5EoaPkSZloVtmgWo=",
+      "requires": {
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "define-property": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+        "engine-base": "https://registry.npmjs.org/engine-base/-/engine-base-0.1.3.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+        "vinyl-item": "https://registry.npmjs.org/vinyl-item/-/vinyl-item-1.0.0.tgz"
+      },
+      "dependencies": {
+        "arr-union": {
+          "version": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        }
+      }
+    },
+    "vm-browserify": {
+      "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "requires": {
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+      }
+    },
+    "void-elements": {
+      "version": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+    },
+    "walker": {
+      "version": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "requires": {
+        "makeerror": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz"
+      }
+    },
+    "ware": {
+      "version": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+      "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+      "requires": {
+        "wrap-fn": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz"
+      }
+    },
+    "warning-symbol": {
+      "version": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz",
+      "integrity": "sha1-uzHdEbeg+dZ6su2V9Fe2WCW7rSE="
+    },
+    "watch": {
+      "version": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+    },
+    "webidl-conversions": {
+      "version": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
+      "integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA="
+    },
+    "weinre": {
+      "version": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
+      "integrity": "sha1-/viqIjkh97QLu71MPtQwL2/QqBM=",
+      "requires": {
+        "express": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+      }
+    },
+    "whatwg-encoding": {
+      "version": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+      "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+      "requires": {
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+        }
+      }
+    },
+    "whatwg-url": {
+      "version": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+      "requires": {
+        "tr46": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+        "webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        }
+      }
+    },
+    "when": {
+      "version": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=",
+      "optional": true
+    },
+    "whet.extend": {
+      "version": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
+    },
+    "which": {
+      "version": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "requires": {
+        "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+      }
+    },
+    "which-module": {
+      "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+    },
+    "wide-align": {
+      "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+      }
+    },
+    "widest-line": {
+      "version": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+      }
+    },
+    "window-size": {
+      "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+    },
+    "wordwrap": {
+      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "worker-farm": {
+      "version": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
+      "integrity": "sha1-pDi8mTp6fRM7y2VHyV7KfP9Il9g=",
+      "requires": {
+        "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "wrap-ansi": {
+      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "wrap-fn": {
+      "version": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+      "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+      "requires": {
+        "co": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+      },
+      "dependencies": {
+        "co": {
+          "version": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "requires": {
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      }
+    },
+    "write-file-atomic": {
+      "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+      }
+    },
+    "write-file-stdout": {
+      "version": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz",
+      "integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE="
+    },
+    "write-json": {
+      "version": "https://registry.npmjs.org/write-json/-/write-json-0.2.2.tgz",
+      "integrity": "sha1-+k4VKennY6T5LwfZhBMX49JI2vM=",
+      "requires": {
+        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+      }
+    },
+    "ws": {
+      "version": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
+      "requires": {
+        "options": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+        "ultron": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+      }
+    },
+    "wtf-8": {
+      "version": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
+    },
+    "xdg-basedir": {
+      "version": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
+    },
+    "xml-name-validator": {
+      "version": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+    },
+    "xmlhttprequest-ssl": {
+      "version": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
+    },
+    "xtend": {
+      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+        "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+      }
+    },
+    "yauzl": {
+      "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+      "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+      "requires": {
+        "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+        "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+      }
+    },
+    "year": {
+      "version": "https://registry.npmjs.org/year/-/year-0.2.1.tgz",
+      "integrity": "sha1-QIOuUgoxiyPshgN/MADLiSvfm7A="
+    },
+    "yeast": {
+      "version": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    }
+  }
+}


### PR DESCRIPTION
Change benchmark app to use [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet).

Involves a few horrible hacks to get Razor views working properly due to the way it creates its own copy of the built assemblies but doesn't copy over the `.deps.json` files.
